### PR TITLE
Updated region assignment for upcoming matches

### DIFF
--- a/plugins/rikki/heroeslounge/components/upcomingmatches/calendar.htm
+++ b/plugins/rikki/heroeslounge/components/upcomingmatches/calendar.htm
@@ -12,15 +12,13 @@
             {% for match in groupMatch %}
             <div class="event-list--game row no-gutters">
             <div class="event-list--division col-sm-12 col-md-3">
-                {% if match.teams[0].region_id == match.teams[1].region_id %}
                 <span class="event-list--region">
-                    {% if match.teams[0].region_id == "1" %}
-                    [EU]
-                    {% elseif match.teams[0].region_id == "2" %}
-                    [NA]
+                    {% if match.playoff.season.region is not null %}
+                    [{{match.playoff.season.region.title}}] 
+                    {% elseif match.teams[0].region_id is not null and match.teams[0].region_id == match.teams[1].region_id %}
+                    [{{match.teams[0].region.title}}] 
                     {% endif %}
                 </span>
-                {% endif %}
                 <span title="{{match.division.title}}" class="hideOverflow">{{match.division.title}}</span>
                 <span class="event-list--time facebook">
                     @{{match.wbp | date('H:i', timezone)}}


### PR DESCRIPTION
Check the tournament region first, which may assign regions to matches with TBD teams. If no region assigned in the tournament/season, use the teams' regions to determine the proper region tag.

Dev screenshot - regions are being pulled in for all matches now
![region cal](https://user-images.githubusercontent.com/10934093/47270154-36cceb80-d51c-11e8-81fa-e7e07e068ab4.PNG)
