### PR TITLE
Allow captains to promote another player to captain

### DIFF
--- a/plugins/rikki/heroeslounge/components/ManageTeam.php
+++ b/plugins/rikki/heroeslounge/components/ManageTeam.php
@@ -222,6 +222,22 @@ class ManageTeam extends ComponentBase
         return Redirect::refresh();
     }
 
+    public function onPromoteMemberToCaptain()
+    {
+        // Demote current captain
+        $currentCaptain = $this->user->sloth;
+        $currentCaptain->is_captain = 0;
+        $currentCaptain->save();
+
+        // // Promote user to captain
+        $userToPromote = $this->players->where('title', post('promote'))->first();
+        $userToPromote->is_captain = 1;
+        $userToPromote->save();
+        
+        Flash::success($userToPromote->title.' has been promoted to captain');
+        return Redirect::to('/team/view/'.$this->team->slug);
+    }
+
     public function onRosterSave()
     {
         if ($this->rosterLocked == false) {

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -116,6 +116,9 @@
                             %} 1 {% endif %}
                         </div>
                         <input class="form-control" placeholder="Captain" type="text" value="{{__SELF__.user.username}}" disabled>
+                        <div class="input-group-addon captain-icon">
+                            <i class="icon fa fa-star" title="Captain" style="color: gold;"></i>
+                        </div>
                     </div>
                     <div class="input-group col-4">
                         <label for="captain" class="sr-only">Sloth 2</label>
@@ -128,17 +131,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 2" name="sl2" type="text" value="{{__SELF__.players[0].user.username}}"
                         {% if __SELF__.players[0].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[0].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[0].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[0].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[0].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[0].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[0].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[0].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="input-group col-4">
@@ -151,18 +167,31 @@
                             %} 3 {% endif %}
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 3" name="sl3" type="text" value="{{__SELF__.players[1].user.username}}"
-                        {% if __SELF__.players[1].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[1].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[1].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
+                        {% if __SELF__.players[1].user and not __SELF__.rosterLocked %} disabled>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[1].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[1].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[1].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[1].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[1].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -207,17 +207,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 4" name="sl4" type="text" value="{{__SELF__.players[2].user.username}}"
                         {% if __SELF__.players[2].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[2].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[2].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[2].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[2].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[2].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[2].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[2].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="input-group col-4">
@@ -231,17 +244,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 5" name="sl5" type="text" value="{{__SELF__.players[3].user.username}}"
                         {% if __SELF__.players[3].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[3].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[3].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[3].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[3].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[3].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[3].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[3].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="input-group col-4">
@@ -255,17 +281,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 6" name="sl6" type="text" value="{{__SELF__.players[4].user.username}}"
                         {% if __SELF__.players[4].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[4].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[4].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[4].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[4].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[4].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[4].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[4].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>
@@ -281,17 +320,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 7" name="sl7" type="text" value="{{__SELF__.players[5].user.username}}"
                         {% if __SELF__.players[5].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[5].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[5].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[5].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[5].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[5].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[5].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[5].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="input-group col-4">
@@ -305,17 +357,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 8" name="sl8" type="text" value="{{__SELF__.players[6].user.username}}"
                         {% if __SELF__.players[6].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[6].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[6].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[6].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[6].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[6].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[6].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[6].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                     <div class="input-group col-4">
@@ -329,17 +394,30 @@
                         </div>
                         <input class="form-control autocomplete" placeholder="Sloth 9" name="sl9" type="text" value="{{__SELF__.players[7].user.username}}"
                         {% if __SELF__.players[7].user and not  __SELF__.rosterLocked %} disabled>
-                        <div class="input-group-btn">
-                          <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                  data-request="{{__SELF__}}::onMemberRemove"
-                                  data-request-confirm="Do you want to remove {{__SELF__.players[7].user.username}} from your roster?"
-                                  data-request-data="remove: '{{__SELF__.players[7].user.username}}'"
-                                  title="Remove Player" class="close" type="button">
-                            <span aria-hidden="true">
-                              &times;</span>
-                          </button>
-                        </div>
                         {% else %}>
+                        {% endif %}
+                        {% if __SELF__.players[7].user %}
+                            <div class="input-group-btn">
+                                <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                        data-request="{{__SELF__}}::onPromoteMemberToCaptain"
+                                        data-request-confirm="Do you want to promote {{__SELF__.players[7].user.username}} to Captain?"
+                                        data-request-data="promote: '{{__SELF__.players[7].user.username}}'"
+                                        title="Promote Player to Captain" class="close" type="button">
+                                    <i class="promote-icon fa fa-star-o" title="Promote" style="color: black;" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            {% if not __SELF__.rosterLocked %}
+                            <div class="input-group-btn">
+                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                    data-request="{{__SELF__}}::onMemberRemove"
+                                    data-request-confirm="Do you want to remove {{__SELF__.players[7].user.username}} from your roster?"
+                                    data-request-data="remove: '{{__SELF__.players[7].user.username}}'"
+                                    title="Remove Player" class="close" type="button">
+                                <span aria-hidden="true">
+                                &times;</span>
+                            </button>
+                            </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/themes/HeroesLounge-Theme/assets/css/custom.css
+++ b/themes/HeroesLounge-Theme/assets/css/custom.css
@@ -181,3 +181,23 @@ i.website-white:hover
 {
     opacity:1;
 }
+
+.input-group-addon.captain-icon {
+    height: 40px;
+    border-radius: 0;
+    padding: 7px;
+}
+.input-group-addon.captain-icon .icon {
+    font-size: 16px;
+    text-shadow:
+        0 0 1px #495057,
+        0 0 1px #495057,
+        0 0 1px #495057,
+        0 0 1px #495057;
+}
+
+.input-group-btn .promote-icon {
+    position: relative;
+    top: -3px;
+    font-size: 16px;
+}


### PR DESCRIPTION
Addresses #7 

On the team management page, add a star icon to the right side of player names.
For the captain, it's a gold star to indicate captaincy. For other players, it's a button the captain can click the button to promote a given user to Captain of the team.

![manage](https://user-images.githubusercontent.com/10934093/48318988-a9316880-e5bc-11e8-860c-8edd0de69882.PNG)
![confirm](https://user-images.githubusercontent.com/10934093/48318989-af274980-e5bc-11e8-8f1a-2564b6abb80d.PNG)
![done](https://user-images.githubusercontent.com/10934093/48318993-b8181b00-e5bc-11e8-9763-83f9a0e30cbd.PNG)
