### PR TITLE
Add client-side validation to image uploads

### DIFF
--- a/plugins/rikki/heroeslounge/assets/js/selectFile.js
+++ b/plugins/rikki/heroeslounge/assets/js/selectFile.js
@@ -23,6 +23,34 @@ jQuery(function() {
           }
 
       });
+
+      // Client-size checks for image uploaders
+      // Images must be PNG and under 100MB 
+      jQuery("input[type='file'][accept='image/png']").on('change', validateImageFileAndSize);
+
+      function validateImageFileAndSize() {
+          if (this.files.length === 0) {
+              return;
+          }
+          
+          var fieldName = jQuery(this).attr('name');
+          var errorDiv = jQuery(`#${fieldName}UploadError`);
+
+          var uploadedFile = this.files[0];
+          errorDiv.text("");
+          var errors = [];
+          if (uploadedFile.type !== "image/png") {
+              errors.push("File must be a PNG.");
+          }
+          if (uploadedFile.size > 104857600) {
+              errors.push("Size exceeds 100MB.");
+          }
+
+          if (errors.length > 0) {
+              errorDiv.text(errors.join(" "));
+              jQuery("input.filename").val("");
+              this.value = "";
+          }
+      }
   });
-  
 });

--- a/plugins/rikki/heroeslounge/components/createteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/createteam/default.htm
@@ -40,13 +40,15 @@
                 <label class="input-group-btn form-control-label" style="height:40px">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="logo" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="logo" style="display:none">
                         </span>
                     </label>
                 <input type="text" class="form-control" readonly="true">
             </div>
+            <div><small id="logoUploadError" class="text-danger"></small></div>
             <small id="shortLogoBlock" class="text-muted">
                 The Logo will be used to recognize your team even if no team name is shown.<br />
+                Image must be a PNG, under 100MB, and under 1280x1280 pixels.<br />
                 We suggest to take a square image e.g. 128x128 Pixel.
                 </small>
         </div>
@@ -59,13 +61,15 @@
                 <label class="input-group-btn form-control-label" style="height:40px">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="banner" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="banner" style="display:none">
                         </span>
                     </label>
                 <input type="text" class="form-control" readonly="true">
             </div>
+            <div><small id="bannerUploadError" class="text-danger"></small></div>
             <small id="shortBannerBlock" class="text-muted">
                 The Banner will be used to spice up your Teams Profile Page.<br />
+                Image must be a PNG and under 100MB in size.<br />
                 We suggest to take a rectangular image e.g. 1000x250 Pixel.
                 </small>
         </div>

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -187,9 +187,11 @@
                             <input type="file" accept="image/png" class="form-control" name="logo" style="display:none" id="logoChooser">
                         </span>
                     </label>
-                    <input type="text" class="form-control form-control-warning" readonly="true" aria-describedby="shortLogoBlock">
+                    <input type="text" class="form-control form-control-warning filename" readonly="true" aria-describedby="shortLogoBlock">
                     <div><small id="logoUploadError" class="text-danger"></small></div>
-                    <small class="text-muted">Uploading a new logo will replace your current logo.</small>
+                    <small class="text-muted">Uploading a new logo will replace your current logo.<br />
+                    Image must be a PNG, under 100MB, and under 1280x1280 pixels.
+                    </small>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Submit Logo</button> {{form_close()}}
             </div>
@@ -398,28 +400,51 @@
         jQuery('.modal-footer .btn-primary').attr('data-request-data', `remove: '${playerName}'`);
     }
 
+    function validateLogoUpload() {
+        if (this.files.length === 0) {
+            return;
+        }
+
+        var uploadedFile = this.files[0];
+        var errorDiv = jQuery("#logoUploadError");
+        errorDiv.text("");
+
+        // Check that file is a PNG
+        if (uploadedFile.type !== "image/png") {
+            errorDiv.text("File must be a png.");
+            jQuery("input.filename").val("");
+            this.value = "";
+        } else {
+            img = new Image();
+            var _URL = window.URL || window.webkitURL;
+            img.src = _URL.createObjectURL(uploadedFile);
+            img.onload = () => {
+                var errors = [];
+                // Check image size
+                if (uploadedFile.size > 104857600) {
+                    errors.push("Size exceeds 100MB.");
+                }
+                // Check image dimensions
+                if (img.width > 1280 || img.height > 1280) {
+                    errors.push("Dimensions exceed 1028x1028.");
+                }
+
+                if (errors.length > 0) {
+                    errorDiv.text(errors.join(" "));
+                    jQuery("input.filename").val("");
+                    this.value = "";
+                }
+            };
+        }
+    }
+
     jQuery(document).ready(function () {
         // Roster update modals
         jQuery(".promote-btn").on('click', renderPromoteModal);
         jQuery(".remove-btn").on('click', renderRemoveModal);
 
         // File check for logo upload
-        jQuery("#logoChooser").on('change', function() {
-            if(this.files.length === 0) {
-                return;
-            }
-
-            var uploadedFile = this.files[0];
-            var errorDiv = jQuery("#logoUploadError");
-            if(uploadedFile.type !== "image/png") {
-                errorDiv.text("File must be a png");
-                this.value = "";
-            }
-            if(uploadedFile.size >= 104857600){ // 100MB
-                errorDiv.text("File size must be under 100MB");
-                this.value = "";
-            };
-        });
+        jQuery("#logoChooser").on('change', validateLogoUpload);
         
     });
 

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -184,10 +184,11 @@
                     <label class="input-group-btn form-control-label" style="height:40px;display:grid">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="logo" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="logo" style="display:none" id="logoChooser">
                         </span>
                     </label>
                     <input type="text" class="form-control form-control-warning" readonly="true" aria-describedby="shortLogoBlock">
+                    <div><small id="logoUploadError" class="text-danger"></small></div>
                     <small class="text-muted">Uploading a new logo will replace your current logo.</small>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Submit Logo</button> {{form_close()}}
@@ -398,8 +399,28 @@
     }
 
     jQuery(document).ready(function () {
+        // Roster update modals
         jQuery(".promote-btn").on('click', renderPromoteModal);
         jQuery(".remove-btn").on('click', renderRemoveModal);
+
+        // File check for logo upload
+        jQuery("#logoChooser").on('change', function() {
+            if(this.files.length === 0) {
+                return;
+            }
+
+            var uploadedFile = this.files[0];
+            var errorDiv = jQuery("#logoUploadError");
+            if(uploadedFile.type !== "image/png") {
+                errorDiv.text("File must be a png");
+                this.value = "";
+            }
+            if(uploadedFile.size >= 104857600){ // 100MB
+                errorDiv.text("File size must be under 100MB");
+                this.value = "";
+            };
+        });
+        
     });
 
 </script>

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -184,7 +184,7 @@
                     <label class="input-group-btn form-control-label" style="height:40px;display:grid">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" accept="image/png" class="form-control" name="logo" style="display:none" id="logoChooser">
+                            <input type="file" accept="image/png" class="form-control" name="logo" style="display:none">
                         </span>
                     </label>
                     <input type="text" class="form-control form-control-warning filename" readonly="true" aria-describedby="shortLogoBlock">
@@ -219,11 +219,13 @@
                     <label class="input-group-btn form-control-label" style="height:40px;display:grid">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="banner" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="banner" style="display:none">
                         </span>
                     </label>
                     <input type="text" class="form-control form-control-warning" readonly="true" aria-describedby="shortBannerBlock">
-                    <small class="text-muted">Uploading a new banner will replace your current banner.</small>
+                    <div><small id="bannerUploadError" class="text-danger"></small></div>
+                    <small class="text-muted">Uploading a new banner will replace your current banner.<br/>
+                    Image must be a PNG and under 100MB in size.</small>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Submit Banner</button> {{form_close()}}
             </div>
@@ -400,52 +402,10 @@
         jQuery('.modal-footer .btn-primary').attr('data-request-data', `remove: '${playerName}'`);
     }
 
-    function validateLogoUpload() {
-        if (this.files.length === 0) {
-            return;
-        }
-
-        var uploadedFile = this.files[0];
-        var errorDiv = jQuery("#logoUploadError");
-        errorDiv.text("");
-
-        // Check that file is a PNG
-        if (uploadedFile.type !== "image/png") {
-            errorDiv.text("File must be a png.");
-            jQuery("input.filename").val("");
-            this.value = "";
-        } else {
-            img = new Image();
-            var _URL = window.URL || window.webkitURL;
-            img.src = _URL.createObjectURL(uploadedFile);
-            img.onload = () => {
-                var errors = [];
-                // Check image size
-                if (uploadedFile.size > 104857600) {
-                    errors.push("Size exceeds 100MB.");
-                }
-                // Check image dimensions
-                if (img.width > 1280 || img.height > 1280) {
-                    errors.push("Dimensions exceed 1028x1028.");
-                }
-
-                if (errors.length > 0) {
-                    errorDiv.text(errors.join(" "));
-                    jQuery("input.filename").val("");
-                    this.value = "";
-                }
-            };
-        }
-    }
-
     jQuery(document).ready(function () {
         // Roster update modals
         jQuery(".promote-btn").on('click', renderPromoteModal);
         jQuery(".remove-btn").on('click', renderRemoveModal);
-
-        // File check for logo upload
-        jQuery("#logoChooser").on('change', validateLogoUpload);
-        
     });
 
 </script>

--- a/plugins/rikki/heroeslounge/components/slothaccount/update.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/update.htm
@@ -118,11 +118,13 @@
                     <label class="input-group-btn form-control-label" style="height:40px;display:grid">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="avatar" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="avatar" style="display:none">
                         </span>
                     </label>
                     <input type="text" class="form-control form-control-warning" readonly="true" aria-describedby="shortLogoBlock">
-                    <small class="text-muted">Uploading a new avatar will replace your current avatar.</small>
+                    <div><small id="avatarUploadError" class="text-danger"></small></div>
+                    <small class="text-muted">Uploading a new avatar will replace your current avatar.<br />
+                        Image must be a PNG, under 100MB, and under 1280x1280 pixels.</small>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Submit Avatar</button> {{form_close()}}
             </div>
@@ -149,11 +151,13 @@
                     <label class="input-group-btn form-control-label" style="height:40px;display:grid">
                         <span class="btn btn-primary" type="button">
                             Browse..
-                            <input type="file" class="form-control" name="banner" style="display:none">
+                            <input type="file" accept="image/png" class="form-control" name="banner" style="display:none">
                         </span>
                     </label>
                     <input type="text" class="form-control form-control-warning" readonly="true" aria-describedby="shortBannerBlock">
-                    <small class="text-muted">Uploading a new banner will replace your current banner.</small>
+                    <div><small id="bannerUploadError" class="text-danger"></small></div>
+                    <small class="text-muted">Uploading a new banner will replace your current banner.<br />
+                        Image must be a PNG and under 100MB in size.</small>
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">Submit Banner</button> {{form_close()}}
             </div>


### PR DESCRIPTION
Related to #38 

This diff adds an image validator function within `selectFile.js`. The JS file is shared by all pages that contain a file uploader, and adds an event handler on change to image uploaders. The validator will raise errors and clear the uploader field if a user attempts to upload a non-PNG image or attempts to upload a file >100MB in size.

We also add the extra attribute `accept="image/png"` to all logo, avatar, and banner uploaders to limit the file selection to PNG by default. We also add some helpful text under each of these fields to let users know the upload restrictions.

This is what the error looks like after a user attempts to upload an invalid file:
![capture](https://user-images.githubusercontent.com/10934093/48973829-a17eb480-effd-11e8-804c-ca021ea264d8.PNG)

