### PR TITLE
Force user to pick region in registration

### DIFF
--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -172,6 +172,7 @@ class SlothAccount extends UserAccount
                 'password' => 'required|between:4,255|confirmed',
                 'battle_tag' => 'required|unique:rikki_heroeslounge_sloths|regex:/^[\p{L}\p{Mn}][\p{L}\p{Mn}0-9]{2,11}#[0-9]{1,6}+$/u',
                 'discord_tag' => 'required|unique:rikki_heroeslounge_sloths|regex:/[\s\S]*#[0-9]{1,10}+$/u',
+                'region_id' => 'required|exists:rikki_heroeslounge_regions,id'
             ];
 
             if ($this->loginAttribute() == UserSettings::LOGIN_USERNAME) {

--- a/plugins/rikki/heroeslounge/components/slothaccount/register.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/register.htm
@@ -23,7 +23,7 @@
 
     <div class="form-group">
         <div class="alert alert-warning">
-            Registering for Heroes Lounge requires you to join our 
+            Registering for Heroes Lounge requires you to join our
             <a href="https://discordapp.com/invite/aePkBsZ">
                 Discord.
             </a> It may take several minutes until we verify that you have joined our server, so in case you can't register right away, please try again later.
@@ -53,7 +53,8 @@
     </div>
     <div class="form-group">
         <label for="registerRegion">Region</label><br>
-        <select name="region_id" id="registerRegion">
+        <select name="region_id" id="registerRegion" required>
+          <option value="0">select region</option selected>
             {% for region in __SELF__.regions %}
                 <option value="{{region.id}}">{{region.title}}</option>
             {% endfor %}
@@ -70,7 +71,7 @@
     <div class="form-group">
         <label for="newsletterCheckbox">Subscribe to our newsletter</label>
         <input name="newsletter_subscription" type="checkbox" id="newsletterCheckbox"/>
-        
+
     </div>
     <button type="button" class="btn btn-primary" data-toggle="modal" data-target=".bd-example-modal-lg">Register</button>
 


### PR DESCRIPTION
Regarding #42 

Adds a "select region" placeholder option to region when a new user registers, forcing them to pick a region.
If the user fails to select a region, they'll get the following error:

![region selection error](https://user-images.githubusercontent.com/6303961/49101404-633ffa00-f276-11e8-8550-1048c1043feb.png)

I'm unsure if I should rename the identifier to "region" to have the error be more clear to the user about what they missed or if I can leave it like this.