### PR TITLE
Update filter for managing matches

### DIFF
--- a/plugins/rikki/heroeslounge/components/ManageMatches.php
+++ b/plugins/rikki/heroeslounge/components/ManageMatches.php
@@ -1,6 +1,6 @@
 <?php namespace Rikki\Heroeslounge\Components;
 
- 
+
 use Cms\Classes\ComponentBase;
 use Rikki\Heroeslounge\Models\Team as Teams;
 
@@ -37,11 +37,9 @@ class ManageMatches extends ComponentBase
             $this->team = Teams::where('slug', $this->param('slug'))->first();
             if ($this->team) {
                 $this->matches = $this->team->matches()->where(function ($q) {
-                    $q->whereNull('wbp')->orWhere(function ($q) {
-                        $q->whereNotNull('wbp')->where('winner_id', null);
-                    });
+                    $q->where('is_played', false)
                 })->get();
-              
+
                 $component = $this->addComponent(
                             'Rikki\Heroeslounge\Components\UpdateMatch',
                             'updateMatch',
@@ -49,14 +47,14 @@ class ManageMatches extends ComponentBase
                                                    'deferredBinding'   => true,
                             ]
                 );
-                                       
+
                 $component = $this->addComponent(
                             'Rikki\Heroeslounge\Components\ScheduleMatch',
                             'scheduleMatch',
                             [
                                 'deferredBinding'   => true,
                             ]
-                                       
+
                 );
             }
         }

--- a/plugins/rikki/heroeslounge/models/match/fields.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields.yaml
@@ -21,6 +21,10 @@ secondaryTabs:
             readOnly: true
             tab: Misc
             type: datepicker
+        is_played:
+          label: 'Is played'
+          type: checkbox
+          tab: Misc
         winner:
             label: 'Winning Team'
             type: relation


### PR DESCRIPTION
Fixes #51 
- Now selects matches that need managing solely by is_played
- Filtering to show a schedule or report box happens on the managematches component
- You can toggle the is_played variable in the backend to allow matches to "reappear for teams to submit results"
