### PR TITLE
Fixed disbanding teams in back-end not removing team members

### DIFF
--- a/plugins/rikki/heroeslounge/controllers/Team.php
+++ b/plugins/rikki/heroeslounge/controllers/Team.php
@@ -46,7 +46,7 @@ class Team extends Controller
         $dis = post('Team[disbanded]');
         if($dis == true) {
             $team = $model;
-            $team->sloths->each(function($sloth){
+            $team->sloths->each(function($sloth) use ($team) {
                 if($sloth->is_captain && $team->type == 1) {
                     $sloth->is_captain = false;
                     if (!$sloth->is_divs_captain) {


### PR DESCRIPTION
The `$team` variable was not defined within the loop, thus `$team->type` was not defined.