### PR TITLE
Assigns calendar region from playoffs region instead of season region

### DIFF
--- a/plugins/rikki/heroeslounge/components/upcomingmatches/calendar.htm
+++ b/plugins/rikki/heroeslounge/components/upcomingmatches/calendar.htm
@@ -13,10 +13,10 @@
             <div class="event-list--game row no-gutters">
             <div class="event-list--division col-sm-12 col-md-3">
                 <span class="event-list--region">
-                    {% if match.playoff.season.region is not null %}
-                    [{{match.playoff.season.region.title}}] 
+                    {% if match.playoff.region is not null %}
+                    [{{match.playoff.region.title}}] 
                     {% elseif match.teams[0].region_id is not null and match.teams[0].region_id == match.teams[1].region_id %}
-                    [{{match.teams[0].region.title}}] 
+                    [{{match.teams[0].region.title}}]
                     {% endif %}
                 </span>
                 <span title="{{match.division.title}}" class="hideOverflow">{{match.division.title}}</span>


### PR DESCRIPTION
Playoff regions used to not be defined on the playoff model. This meant that we had to get the region from the associated season. However a region is now defined on the playoff, so we can directly get it from there.

Division S also does not have an associated region, so it didn't associate a region to matches that did not yet have two teams assigned to them.