### PR TITLE
Delete match relations when match is deleted

### DIFF
--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -231,6 +231,16 @@ class Match extends Model
         }
     }
 
+    public function afterDelete()
+    {
+        $this->teams()->detach();
+        $this->casters()->detach();
+        
+        foreach ($this->games as $game) {
+            $game->delete();
+        }
+    }
+
     public function determineWinnerAndSave()
     {
         $t1wins = $this->games->where('winner_id', $this->teams[0]->id)->count();


### PR DESCRIPTION
Fixes #49 
I'm uncertain if this is the best approach, but it removed all of the table entries related to the deleted match.

I tried adding `'delete' => true` to the match model relationship for team, caster and games, but that didn't result in anything happening to the db entries in my local testing.