### PR TITLE
Fix back-end search for season and match creation

### DIFF
--- a/plugins/rikki/heroeslounge/controllers/match/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/match/config_relation.yaml
@@ -10,6 +10,9 @@ teams:
         toolbarPartial: teams_toolbar
     manage:
         showSearch: true
+        recordsPerPage: 20
+        list: $/rikki/heroeslounge/models/team/relation_columns.yaml
+            
 games:
     label: Games
     view: 

--- a/plugins/rikki/heroeslounge/controllers/season/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/season/config_relation.yaml
@@ -39,3 +39,5 @@ teams:
         toolbarPartial: teams_toolbar
     manage:
         showSearch: true
+        recordsPerPage: 20
+        list: $/rikki/heroeslounge/models/team/relation_columns.yaml

--- a/plugins/rikki/heroeslounge/models/team/relation_columns.yaml
+++ b/plugins/rikki/heroeslounge/models/team/relation_columns.yaml
@@ -1,0 +1,14 @@
+columns:
+    title:
+        label: Title
+        type: text
+        searchable: true
+        sortable: true
+    type:
+        label: 'Type (1 - Amateur, 2 - S)'
+        type: text
+        sortable: true
+    disbanded:
+        label: 'Disbanded'
+        type: switch
+        sortable: true


### PR DESCRIPTION
I believe this fixes searching for teams in the back-end when adding teams to a season or a new match.

Also in local testing, setting a recordsPerPage did improve load time when opening the team list.

Not entirely sure about my choice of name for the team list, as it's basically a smaller version of the original `columns.yaml` file on the team model.