### PR TITLE
Updated matches backend

### DIFF
--- a/plugins/rikki/heroeslounge/controllers/Match.php
+++ b/plugins/rikki/heroeslounge/controllers/Match.php
@@ -30,16 +30,11 @@ class Match extends Controller
         $form->addFields([
             'division@create' => [
                 'label' => 'Division',
-                'span' => 'left',
+                'span' => 'right',
                 'type' => 'dropdown',
                 'options' => Division::listDivisionsWithLongTitle(),
                 'showSearch' => false,
                 'emptyOption' => '-- No Division --'
-            ],
-            'round@create' => [
-                'label' => 'Round',
-                'span' => 'auto',
-                'type' => 'number'
             ]
             ]);
     }

--- a/plugins/rikki/heroeslounge/controllers/Match.php
+++ b/plugins/rikki/heroeslounge/controllers/Match.php
@@ -7,6 +7,7 @@ use Rikki\Heroeslounge\Models\Team;
 use Rikki\Heroeslounge\Models\Timeline;
 use Rikki\Heroeslounge\Models\Match as MatchModel;
 use Rikki\Heroeslounge\Models\Game;
+use Rikki\Heroeslounge\Models\Division;
 
 class Match extends Controller
 {
@@ -22,6 +23,25 @@ class Match extends Controller
         parent::__construct();
 
         BackendMenu::setContext('Rikki.Heroeslounge', 'manage-matches','manage-matches');
+    }
+
+    public static function formExtendFields($form)
+    {
+        $form->addFields([
+            'division@create' => [
+                'label' => 'Division',
+                'span' => 'left',
+                'type' => 'dropdown',
+                'options' => Division::listDivisionsWithLongTitle(),
+                'showSearch' => false,
+                'emptyOption' => '-- No Division --'
+            ],
+            'round@create' => [
+                'label' => 'Round',
+                'span' => 'auto',
+                'type' => 'number'
+            ]
+            ]);
     }
 
     public function onRelationButtonApprove()

--- a/plugins/rikki/heroeslounge/models/Division.php
+++ b/plugins/rikki/heroeslounge/models/Division.php
@@ -85,10 +85,21 @@ class Division extends Model
     {
         if ($this->season != null) {
             return $this->season->title . ' - ' . $this->title;
-        } else if ($this->playoff != null && $this->playoff->season != null) {
-            return $this->playoff->season->title . ' - ' . $this->playoff->title;
+        } else if ($this->playoff != null) {
+            return $this->playoff->longTitle . ' - ' . $this->title;
         }
         return $this->title;
+    }
+
+    public static function listDivisionsWithLongTitle()
+    {
+        $divisions = Division::all();
+        $list = [];
+
+        foreach ($divisions as $division) {
+            $list[$division->id] = $division->longTitle;
+        }
+        return $list;
     }
 
     public function getActiveTeamsAttribute()

--- a/plugins/rikki/heroeslounge/models/Division.php
+++ b/plugins/rikki/heroeslounge/models/Division.php
@@ -93,13 +93,7 @@ class Division extends Model
 
     public static function listDivisionsWithLongTitle()
     {
-        $divisions = Division::all();
-        $list = [];
-
-        foreach ($divisions as $division) {
-            $list[$division->id] = $division->longTitle;
-        }
-        return $list;
+        return Division::all()->keyBy('id')->map(function ($division) { return $division->longTitle; })->toArray();
     }
 
     public function getActiveTeamsAttribute()

--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -82,6 +82,11 @@ class Match extends Model
         ]
     ];
 
+    public function listWinnerOptions($fieldname, $value, $formData)
+    {
+        return [$formData["teams"][0]['id'] => $formData["teams"][0]['title'], $formData["teams"][1]['id'] => $formData["teams"][1]['title']];
+    }
+
     public function getCasterIds()
     {
         return $this->casters

--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -9,7 +9,6 @@ use Rikki\Heroeslounge\classes\hotfixes as hotfixes;
 use Rikki\Heroeslounge\Models\Season as Season;
 use Rikki\Heroeslounge\Models\Playoff;
 use Rikki\Heroeslounge\Models\Team;
-use Rikki\Heroeslounge\Models\Division;
 use Carbon\Carbon;
 use Log;
 /**
@@ -83,14 +82,9 @@ class Match extends Model
         ]
     ];
 
-    public function listWinnerOptions($fieldname, $value, $formData)
+    public function listParticipatingTeamsForBackend($fieldname, $value, $formData)
     {
         return [$formData["teams"][0]['id'] => $formData["teams"][0]['title'], $formData["teams"][1]['id'] => $formData["teams"][1]['title']];
-    }
-
-    public function divisionsLongTitleDropdown()
-    {
-        return Division::listDivisionsWithLongTitle();
     }
 
     public function getCasterIds()

--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -9,6 +9,7 @@ use Rikki\Heroeslounge\classes\hotfixes as hotfixes;
 use Rikki\Heroeslounge\Models\Season as Season;
 use Rikki\Heroeslounge\Models\Playoff;
 use Rikki\Heroeslounge\Models\Team;
+use Rikki\Heroeslounge\Models\Division;
 use Carbon\Carbon;
 use Log;
 /**
@@ -85,6 +86,11 @@ class Match extends Model
     public function listWinnerOptions($fieldname, $value, $formData)
     {
         return [$formData["teams"][0]['id'] => $formData["teams"][0]['title'], $formData["teams"][1]['id'] => $formData["teams"][1]['title']];
+    }
+
+    public function divisionsLongTitleDropdown()
+    {
+        return Division::listDivisionsWithLongTitle();
     }
 
     public function getCasterIds()

--- a/plugins/rikki/heroeslounge/models/match/fields.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields.yaml
@@ -24,6 +24,11 @@ Tabs:
             label: Is played
             type: checkbox
             tab: General
+        round:
+            label: 'Round'
+            span: left
+            type: number
+            tab: General
         teams:
             label: Participating Teams
             span: left
@@ -35,7 +40,7 @@ Tabs:
             label: Winning Team
             span: left
             type: dropdown
-            options: listWinnerOptions
+            options: listParticipatingTeamsForBackend
             showSearch: false
             emptyOption: -- No Team --
             tab: General

--- a/plugins/rikki/heroeslounge/models/match/fields.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields.yaml
@@ -1,40 +1,43 @@
 Tabs:
     fields:
-        wbp:
-            label: 'Schedule for'
+        tbp:
+            label: To be played before
             span: auto
             type: datepicker
+            disabled: true
             mode: datetime
             tab: General
         schedule_date:
-            label: 'Has to be scheduled until'
+            label: To be scheduled before
+            span: auto
+            type: datepicker
+            disabled: true
+            mode: datetime
+            tab: General
+        wbp:
+            label: Schedule for
             span: auto
             type: datepicker
             mode: datetime
-            readOnly: true
-            tab: General
-        tbp:
-            label: 'To be played until'
-            span: auto
-            type: datepicker
-            mode: datetime
-            readOnly: true
-            tab: General
-        round:
-            label: 'Round'
-            span: left
-            type: number
             tab: General
         is_played:
-            label: 'Is played'
+            label: Is played
             type: checkbox
             tab: General
-        winner:
-            label: 'Winning Team'
+        teams:
+            label: Participating Teams
             span: left
             type: relation
             select: title
-            emptyOption: '-- no team --'
+            disabled: true
+            tab: General
+        winner:
+            label: Winning Team
+            span: left
+            type: dropdown
+            options: listWinnerOptions
+            showSearch: false
+            emptyOption: -- No Team --
             tab: General
         casters:
             label: Casters

--- a/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
@@ -16,14 +16,3 @@ fields:
         span: auto
         type: datepicker
         mode: datetime
-    division:
-        label: Division
-        span: left
-        type: dropdown
-        options: divisionsLongTitleDropdown
-        showSearch: false
-        emptyOption: -- No Division --
-    round:
-        label: 'Round'
-        span: auto
-        type: number

--- a/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
@@ -16,3 +16,7 @@ fields:
         span: auto
         type: datepicker
         mode: datetime
+    round:
+        label: Round
+        span: left
+        type: number

--- a/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
@@ -1,16 +1,16 @@
 fields:
-    schedule_date:
-        label: 'Has to be scheduled until'
-        span: auto
-        type: datepicker
-        readOnly: false
-        mode: datetime
     tbp: 
-        label: 'To be played until'
+        label: 'To be played before'
         span: auto
         type: datepicker
         mode: datetime
         readOnly: false
+    schedule_date:
+        label: 'To be scheduled before'
+        span: auto
+        type: datepicker
+        readOnly: false
+        mode: datetime
     wbp:
         label: 'Schedule for'
         span: auto

--- a/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
+++ b/plugins/rikki/heroeslounge/models/match/fields_on_create.yaml
@@ -1,29 +1,29 @@
 fields:
     tbp: 
-        label: 'To be played before'
+        label: To be played before
         span: auto
         type: datepicker
         mode: datetime
         readOnly: false
     schedule_date:
-        label: 'To be scheduled before'
+        label: To be scheduled before
         span: auto
         type: datepicker
         readOnly: false
         mode: datetime
     wbp:
-        label: 'Schedule for'
+        label: Schedule for
         span: auto
         type: datepicker
         mode: datetime
+    division:
+        label: Division
+        span: left
+        type: dropdown
+        options: divisionsLongTitleDropdown
+        showSearch: false
+        emptyOption: -- No Division --
     round:
         label: 'Round'
-        span: left
+        span: auto
         type: number
-    division:
-        label: 'Division'
-        span: left
-        type: relation
-        placeholder: 'null'
-        nameFrom: title
-            


### PR DESCRIPTION
Fixes #85 #86  
Removed the match round from update match. I don't think this needs to editable after a match has been created. 

Disabled updating of the play and schedule deadlines from the update match backend.

Renamed fields to be more clear, added more intuitive ordering and made create/update match consistent.

Display teams participating in a match and filtered the winner selection based on the these participating teams, instead of the old massive drop down.

