### PR TITLE
only send timezone at start of session, use everywhere

### DIFF
--- a/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
+++ b/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
@@ -1,0 +1,52 @@
+<?php namespace Rikki\Heroeslounge\Classes\Helpers;
+
+use Auth;
+use Config;
+use Session;
+
+class TimezoneHelper
+{
+    private const TIMEZONE_KEY = 'timezone';
+
+    public static $defaultTimezone;
+
+    private static function defaultTimezone()
+    {
+        if (!self::$defaultTimezone)
+        {
+            self::$defaultTimezone = Config::get('app.timezone', 'Europe/Berlin');
+        }
+        return self::$defaultTimezone;
+    }
+
+    public static function getTimezone()
+    {
+        return Session::get(self::TIMEZONE_KEY, self::defaultTimezone());
+    }
+
+    public static function setTimezone()
+    {
+        if (isset($_POST[self::TIMEZONE_KEY])) {
+            $timezoneName = $_POST[self::TIMEZONE_KEY];
+        } else {
+            $timezoneName = self::defaultTimezone();
+        }
+        if (!in_array($timezoneName, timezone_identifiers_list())) {
+            $timezoneName = self::defaultTimezone();
+        }
+        Session::put(self::TIMEZONE_KEY, $timezoneName);
+
+        $user = Auth::getUser();
+        if ($user) {
+            if ($user->sloth->timezone == '') {
+                $user->sloth->timezone = TimezoneHelper::getTimezone();
+                $user->sloth->save();
+            }
+        }
+    }
+
+    public static function hasTimezone()
+    {
+        return Session::has(self::TIMEZONE_KEY);
+    }
+}

--- a/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
+++ b/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
@@ -6,15 +6,17 @@ use Session;
 
 class TimezoneHelper
 {
+    private const DEFAULT_TIMEZONE = 'UTC';
     private const TIMEZONE_KEY = 'timezone';
 
-    public static $defaultTimezone;
+    private static $defaultTimezone;
 
     private static function defaultTimezone()
     {
         if (!self::$defaultTimezone)
         {
-            self::$defaultTimezone = Config::get('app.timezone', 'Europe/Berlin');
+            self::$defaultTimezone =
+                Config::get('app.timezone', self::DEFAULT_TIMEZONE);
         }
         return self::$defaultTimezone;
     }
@@ -35,14 +37,6 @@ class TimezoneHelper
             $timezoneName = self::defaultTimezone();
         }
         Session::put(self::TIMEZONE_KEY, $timezoneName);
-
-        $user = Auth::getUser();
-        if ($user) {
-            if ($user->sloth->timezone == '') {
-                $user->sloth->timezone = TimezoneHelper::getTimezone();
-                $user->sloth->save();
-            }
-        }
     }
 
     public static function hasTimezone()

--- a/plugins/rikki/heroeslounge/components/UpcomingMatches.php
+++ b/plugins/rikki/heroeslounge/components/UpcomingMatches.php
@@ -8,6 +8,7 @@ use Rikki\Heroeslounge\Models\Season as Seasons;
 use Rikki\Heroeslounge\Models\Division as Divisions;
 use Rikki\Heroeslounge\Models\Match as Matches;
 use Rikki\Heroeslounge\Models\Sloth as Sloths;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 
 use Input;
 use Request;
@@ -106,75 +107,65 @@ class UpcomingMatches extends ComponentBase
 
     public function onMyRender()
     {
-        $timezoneoffset = (int)$_POST['time'];
-        $timezoneName = "Europe/Berlin";
-        if (isset($_POST['timezone'])) {
-            $timezoneName = $_POST['timezone'];
-        }
-
         $id = 0;
         if (isset($_POST['id'])) {
             $id = $_POST['id'];
         }
 
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = "Europe/Berlin";
-        }
         $this->idApp = $this->property("casterFilter");
+
         if ($this->idApp != "accepted" && $this->idApp != "denied") {
+            $timezoneName = TimezoneHelper::getTimezone();
             $this->collectMatches($timezoneName, $id);
 
-        
             $containerId = "#upcomingMatches".$this->idApp;
             return [
-                $containerId => $this->renderPartial('@calendar', ['user' => Auth::getUser(), 'groupMatches' => $this->groupMatches, 'timezone' => $timezoneName])
+                $containerId => $this->renderPartial(
+                    '@calendar', [
+                        'user' => Auth::getUser(),
+                        'groupMatches' => $this->groupMatches,
+                        'timezone' => $timezoneName
+                    ])
             ];
         }
     }
 
     public function onMyRenderAcceptedCasts()
     {
-        $timezoneoffset = (int)$_POST['time'];
-        $timezoneName = "Europe/Berlin";
-        if (isset($_POST['timezone'])) {
-            $timezoneName = $_POST['timezone'];
-        }
-
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = "Europe/Berlin";
-        }
         $this->idApp = $this->property("casterFilter");
+
         if ($this->idApp == "accepted") {
+            $timezoneName = TimezoneHelper::getTimezone();
             $this->collectMatches($timezoneName, $_POST['id']);
-        
-        
+
             $containerId = "#upcomingMatches".$this->idApp;
             return [
-                $containerId => $this->renderPartial('@calendar', ['user' => Auth::getUser(), 'groupMatches' => $this->groupMatches, 'timezone' => $timezoneName])
+                $containerId => $this->renderPartial(
+                    '@calendar', [
+                        'user' => Auth::getUser(),
+                        'groupMatches' => $this->groupMatches,
+                        'timezone' => $timezoneName
+                    ])
             ];
         }
     }
 
     public function onMyRenderDeniedCasts()
     {
-        $timezoneoffset = (int)$_POST['time'];
-        $timezoneName = "Europe/Berlin";
-        if (isset($_POST['timezone'])) {
-            $timezoneName = $_POST['timezone'];
-        }
-
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = "Europe/Berlin";
-        }
         $this->idApp = $this->property("casterFilter");
 
         if ($this->idApp == "denied") {
-
+            $timezoneName = TimezoneHelper::getTimezone();
             $this->collectMatches($timezoneName, $_POST['id']);
-        
+
             $containerId = "#upcomingMatches".$this->idApp;
             return [
-                $containerId => $this->renderPartial('@calendar', ['user' => Auth::getUser(), 'groupMatches' => $this->groupMatches, 'timezone' => $timezoneName])
+                $containerId => $this->renderPartial(
+                    '@calendar', [
+                        'user' => Auth::getUser(),
+                        'groupMatches' => $this->groupMatches,
+                        'timezone' => $timezoneName
+                    ])
             ];
         }
     }

--- a/plugins/rikki/heroeslounge/components/schedulematch/default.htm
+++ b/plugins/rikki/heroeslounge/components/schedulematch/default.htm
@@ -13,10 +13,9 @@
 </div>
 {% put scripts %}
 <script type="text/javascript">
-    
     jQuery(document).ready(function() {
         jQuery.request('{{__SELF__}}::onMyRender', {
-            data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, match_id: {{__SELF__.match.id}} },
+            data: {match_id: {{__SELF__.match.id}} },
             success: function(data) {
                 this.success(data).done(function() {
                     jQuery('.match').datetimepicker({
@@ -30,7 +29,5 @@
             }
         })
     });
-    
-
 </script>
 {% endput %}

--- a/plugins/rikki/heroeslounge/components/schedulematch/schedulebox.htm
+++ b/plugins/rikki/heroeslounge/components/schedulematch/schedulebox.htm
@@ -4,7 +4,6 @@
     <div class="col-md-8 col-8 text-center">
         <input type="text" class="match text-center" style="height:100%" name="date" value="{{__SELF__.match.wbp}}">
         <input type="hidden" name="match_id" value="{{__SELF__.match.id}}">
-        <input type="hidden" name="timezoneName" value="{{timezone}}">
     </div>
 
     <div class="col-md-4 col-4">

--- a/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
+++ b/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
@@ -4,7 +4,7 @@
 <script type="text/javascript">
 jQuery(document).ready(function() {
     jQuery.request('{{__SELF__}}::onMyRender', {
-        data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, id: "{{__SELF__.eid}}" }
+        data: {id: "{{__SELF__.eid}}" }
     })
 });
 </script>
@@ -14,7 +14,7 @@ jQuery(document).ready(function() {
 <script type="text/javascript">
 jQuery(document).ready(function() {
     jQuery.request('{{__SELF__}}::onMyRenderAcceptedCasts', {
-        data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, id: "{{__SELF__.eid}}" }
+        data: {id: "{{__SELF__.eid}}" }
     })
 });
 </script>
@@ -26,7 +26,7 @@ jQuery(document).ready(function() {
 <script type="text/javascript">
 jQuery(document).ready(function() {
     jQuery.request('{{__SELF__}}::onMyRenderDeniedCasts', {
-        data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, id: "{{__SELF__.eid}}" }
+        data: {id: "{{__SELF__.eid}}" }
     })
 });
 </script>

--- a/plugins/rikki/heroeslounge/components/updatematch/default.htm
+++ b/plugins/rikki/heroeslounge/components/updatematch/default.htm
@@ -177,7 +177,7 @@
 <script type="text/javascript">
 jQuery(document).ready(function() {
     jQuery.request('{{__SELF__}}::onMyRender', {
-        data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, match_id: {{__SELF__.match.id}}}
+        data: {match_id: {{__SELF__.match.id}}}
     })
 });
 </script>

--- a/plugins/rikki/heroeslounge/models/Playoff.php
+++ b/plugins/rikki/heroeslounge/models/Playoff.php
@@ -3,8 +3,10 @@
 use Model;
 use Rikki\Heroeslounge\Models\Team;
 use Rikki\Heroeslounge\Models\Match;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 use Carbon\Carbon;
 use Log;
+
 class Playoff extends Model
 {
     public $table = 'rikki_heroeslounge_playoffs';
@@ -16,12 +18,12 @@ class Playoff extends Model
             'Rikki\Heroeslounge\Models\Season',
             'key' => 'season_id',
             'otherKey' => 'id'
-		],
+        ],
         'region' => ['Rikki\Heroeslounge\Models\Region']
     ];
 
     public $hasMany = [
-    	'divisions' => ['Rikki\Heroeslounge\Models\Division'],
+        'divisions' => ['Rikki\Heroeslounge\Models\Division'],
         'matches' => ['Rikki\Heroeslounge\Models\Match']
     ];
 
@@ -47,10 +49,8 @@ class Playoff extends Model
     public function createMatches()
     {
         $playoff = $this;
-        $timezone = 'Europe/Berlin';
+        $timezone = TimezoneHelper::defaultTimezone();
         if ($this->type == 'playoffv1') {
-            //TODO configure dates and timezone from backend
-            $timezone = 'Europe/Berlin';
             $year0 = 2018;
             $month0 = 10;
             $day0 = 12;
@@ -236,7 +236,6 @@ class Playoff extends Model
                         'wbp' => $Time8]
             ];
         } else if ($this->type == 'playoffv2') {
-            $timezone = 'Europe/Berlin';
             $year = 2019;
             $month = 3;
             $day = 2;
@@ -261,7 +260,6 @@ class Playoff extends Model
             $d3 = $this->teams()->where('seed', 12)->firstOrFail();
             $d4 = $this->teams()->where('seed', 16)->firstOrFail();
 
-            
             $groups = [
                 0 => ['title' => 'Group A', 'slug' => 'group-a',
                         'teams' => [0 =>$a1,1 => $a2,2 => $a3,3 => $a4]],
@@ -342,7 +340,6 @@ class Playoff extends Model
             $matchArray[2]['wbp'] = $otherTime;
             $matchArray[3]['wbp'] = $otherTime;
         } else if ($this->type == 'playoffv3') {
-            $timezone = 'Europe/Berlin';
             $year = 2019;
             $month = 3;
             $day = 3;
@@ -510,7 +507,7 @@ class Playoff extends Model
                     ];
             $matchArray = $this->createDEMatches(4, $times);
         }
-        
+
         foreach ($matchArray as $key => $matchEntry) {
             $match = new Match;
             $match->playoff_id = $playoff->id;
@@ -580,7 +577,6 @@ class Playoff extends Model
         }
 
         //lower bracket
-
         for ($roundnumber = 0; $roundnumber < 2*($rounds-1); $roundnumber++) {
             $time = $timeArray[$rounds+$roundnumber];                
             for ($i = 0; $i < 2**($rounds - floor($roundnumber/2) - 2); $i++) {
@@ -778,7 +774,6 @@ class Playoff extends Model
 
     public function getSeedsFromGroups()
     {
-
         if ($this->type == 'playoffv1') {
             $this->teams()->detach();
             $ga = $this->divisions()->where('title', 'Group A')->firstOrFail();

--- a/plugins/rikki/loungeviews/components/Navigation.php
+++ b/plugins/rikki/loungeviews/components/Navigation.php
@@ -39,13 +39,19 @@ class Navigation extends UserAccount
     {
         parent::init();
 
-
-        $this->user = Auth::getUser();
         $this->amateurseasons = Season::where('type', 1)->orderBy('created_at','desc')->get();
         $this->divsseasons = Season::where('type', 2)->orderBy('created_at','desc')->get();
+
+        $this->user = Auth::getUser();
         if ($this->user != null) {
             $this->sloth = SlothModel::getFromUser($this->user);
+
+            if ($this->sloth->timezone == '') {
+                $this->sloth->timezone = TimezoneHelper::getTimezone();
+                $this->sloth->save();
+            }
         }
+
         $component = $this->addComponent(
             'RainLab\Pages\Components\StaticMenu',
             'staticMenuGuides',
@@ -66,16 +72,10 @@ class Navigation extends UserAccount
         );
     }
 
-
-
-
-
     public function onRun()
     {
         return parent::onRun();
     }
-
-
 
     public function onSignIn()
     {
@@ -100,7 +100,6 @@ class Navigation extends UserAccount
             if ($validation->fails()) {
                 throw new ValidationException($validation);
             }
-
 
             /*
              * Authenticate user
@@ -140,10 +139,6 @@ class Navigation extends UserAccount
             }
         }
     }
-
-
- 
-
 
     public function defineProperties()
     {

--- a/plugins/rikki/loungeviews/components/PlayoffOverview.php
+++ b/plugins/rikki/loungeviews/components/PlayoffOverview.php
@@ -5,6 +5,7 @@ use Cms\Classes\ComponentBase;
 use Rikki\Heroeslounge\Models\Match;
 use Rikki\Heroeslounge\Models\Season;
 use Rikki\Heroeslounge\Models\Playoff;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 use Redirect;
 use Flash;
 use Log;
@@ -127,19 +128,12 @@ class PlayoffOverview extends ComponentBase
 
     public function onMyRender()
     {
-        $timezoneoffset = (int)$_POST['time'];
-        $timezoneName = "Europe/Berlin";
-        if (isset($_POST['timezone'])) {
-            $timezoneName = $_POST['timezone'];
-        }
-        
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = "Europe/Berlin";
-        }
-
         $containerId = "#knockout";
         return [
-            $containerId => $this->renderPartial('@bracket', ['timezone' => $timezoneName])
+            $containerId => $this->renderPartial(
+                '@bracket', [
+                    'timezone' => TimezoneHelper::getTimezone()
+                ])
         ];
     }
 

--- a/plugins/rikki/loungeviews/components/ViewMatch.php
+++ b/plugins/rikki/loungeviews/components/ViewMatch.php
@@ -7,6 +7,7 @@ use Rikki\Heroeslounge\Models\Game;
 use Rikki\Heroeslounge\Models\Map;
 use Rikki\Heroeslounge\Models\Match;
 use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 use Auth;
 use Input;
 use Redirect;
@@ -45,27 +46,19 @@ class ViewMatch extends ComponentBase
         }
     }
 
-
     public function onMyRender()
     {
         $this->match = Match::find($this->param('id'));
-        $timezoneoffset = (int)$_POST['time'];
-        $timezoneName = "Europe/Berlin";
-        if (isset($_POST['timezone'])) {
-            $timezoneName = $_POST['timezone'];
-        }
-
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = "Europe/Berlin";
-        }
 
         $containerId = "#matchtime";
         return [
-            $containerId => $this->renderPartial('@matchtime', ['timezone' => $timezoneName])
+            $containerId => $this->renderPartial(
+                '@matchtime', [
+                    'timezone' => TimezoneHelper::getTimezone()
+                ])
         ];
     }
 
-    
     public function defineProperties()
     {
         return [

--- a/plugins/rikki/loungeviews/components/playoffoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/playoffoverview/default.htm
@@ -111,9 +111,7 @@
         {% put scripts %}
         <script type="text/javascript">
         jQuery(document).ready(function() {
-            jQuery.request('{{__SELF__}}::onMyRender', {
-                data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone}
-            })
+            jQuery.request('{{__SELF__}}::onMyRender')
         });
         </script>
         {% endput %}

--- a/plugins/rikki/loungeviews/components/viewmatch/default.htm
+++ b/plugins/rikki/loungeviews/components/viewmatch/default.htm
@@ -109,9 +109,7 @@
 {% put scripts %}
 <script type="text/javascript">
 jQuery(document).ready(function() {
-    jQuery.request('{{__SELF__}}::onMyRender', {
-        data: {time: -new Date().getTimezoneOffset()/60, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone}
-    })
+    jQuery.request('{{__SELF__}}::onMyRender')
 });
 </script>
 {% endput %}

--- a/themes/HeroesLounge-Theme/layouts/blog.htm
+++ b/themes/HeroesLounge-Theme/layouts/blog.htm
@@ -12,30 +12,22 @@ security = "all"
 <?php
 use RainLab\Translate\Models\Message;
 use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 
 function onStart() {
     $this['baseUrl'] = Config::get('app.url');
     Message::setContext(App::getLocale(), $this->page->url);
+    $this['hasTimezone'] = TimezoneHelper::hasTimezone();
 }
 
 function onTimezoneDetection() {
-
-    if (isset($_POST['timezone'])) {
-        $timezoneName = $_POST['timezone'];
-        $user = Auth::getUser();
-        if ($user) {
-            if ($user->sloth->timezone == '') {
-                $user->sloth->timezone = $timezoneName;
-                $user->sloth->save();
-            }
-        }
-    }
-    
+    TimezoneHelper::setTimezone();
 }
 ?>
 ==
 <!DOCTYPE html>
 <html lang="{{ this.theme.site_locale }}">
+{% if not hasTimezone %}
 {% put scripts %}
 <script type="text/javascript">
 jQuery(document).ready(function() {
@@ -45,6 +37,7 @@ jQuery(document).ready(function() {
 });
 </script>
 {% endput %}
+{% endif %}
 <head>
     {% partial 'assets/head' %}
 </head>

--- a/themes/HeroesLounge-Theme/layouts/plain-wide.html
+++ b/themes/HeroesLounge-Theme/layouts/plain-wide.html
@@ -14,30 +14,22 @@ security = "all"
 <?php
 use RainLab\Translate\Models\Message;
 use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 
 function onStart() {
     $this['baseUrl'] = Config::get('app.url');
     Message::setContext(App::getLocale(), $this->page->url);
+    $this['hasTimezone'] = TimezoneHelper::hasTimezone();
 }
 
 function onTimezoneDetection() {
-
-    if (isset($_POST['timezone'])) {
-        $timezoneName = $_POST['timezone'];
-        $user = Auth::getUser();
-        if ($user) {
-            if ($user->sloth->timezone == '') {
-                $user->sloth->timezone = $timezoneName;
-                $user->sloth->save();
-            }
-        }
-    }
-    
+    TimezoneHelper::setTimezone();
 }
 ?>
 ==
 <!DOCTYPE html>
 <html lang="{{ this.theme.site_locale }}">
+{% if not hasTimezone %}
 {% put scripts %}
 <script type="text/javascript">
 jQuery(document).ready(function() {
@@ -47,6 +39,7 @@ jQuery(document).ready(function() {
 });
 </script>
 {% endput %}
+{% endif %}
 <head>
     {% partial 'assets/head' %}
 </head>

--- a/themes/HeroesLounge-Theme/layouts/plain-with-sidebar.htm
+++ b/themes/HeroesLounge-Theme/layouts/plain-with-sidebar.htm
@@ -14,30 +14,22 @@ security = "all"
 <?php
 use RainLab\Translate\Models\Message;
 use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 
 function onStart() {
     $this['baseUrl'] = Config::get('app.url');
     Message::setContext(App::getLocale(), $this->page->url);
+    $this['hasTimezone'] = TimezoneHelper::hasTimezone();
 }
 
 function onTimezoneDetection() {
-
-    if (isset($_POST['timezone'])) {
-        $timezoneName = $_POST['timezone'];
-        $user = Auth::getUser();
-        if ($user) {
-            if ($user->sloth->timezone == '') {
-                $user->sloth->timezone = $timezoneName;
-                $user->sloth->save();
-            }
-        }
-    }
-    
+    TimezoneHelper::setTimezone();
 }
 ?>
 ==
 <!DOCTYPE html>
 <html lang="{{ this.theme.site_locale }}">
+{% if not hasTimezone %}
 {% put scripts %}
 <script type="text/javascript">
 jQuery(document).ready(function() {
@@ -47,7 +39,7 @@ jQuery(document).ready(function() {
 });
 </script>
 {% endput %}
-
+{% endif %}
 <head>
     {% partial 'assets/head' %}
 </head>

--- a/themes/HeroesLounge-Theme/layouts/plain.htm
+++ b/themes/HeroesLounge-Theme/layouts/plain.htm
@@ -14,30 +14,22 @@ security = "all"
 <?php
 use RainLab\Translate\Models\Message;
 use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 
 function onStart() {
     $this['baseUrl'] = Config::get('app.url');
     Message::setContext(App::getLocale(), $this->page->url);
+    $this['hasTimezone'] = TimezoneHelper::hasTimezone();
 }
 
 function onTimezoneDetection() {
-
-    if (isset($_POST['timezone'])) {
-        $timezoneName = $_POST['timezone'];
-        $user = Auth::getUser();
-        if ($user) {
-            if ($user->sloth->timezone == '') {
-                $user->sloth->timezone = $timezoneName;
-                $user->sloth->save();
-            }
-        }
-    }
-    
+    TimezoneHelper::setTimezone();
 }
 ?>
 ==
 <!DOCTYPE html>
 <html lang="{{ this.theme.site_locale }}">
+{% if not hasTimezone %}
 {% put scripts %}
 <script type="text/javascript">
 jQuery(document).ready(function() {
@@ -47,6 +39,7 @@ jQuery(document).ready(function() {
 });
 </script>
 {% endput %}
+{% endif %}
 <head>
     {% partial 'assets/head' %}
 </head>


### PR DESCRIPTION
Resolves #65 

This ~~does not~~ DOES appear to work quite the way I want: even though it does successfully set the timezone on the session, and it seems to load it just fine, the check for "hasTimezone" seems cached or not updated somewhere because it sends the timezone repeatedly if you reload the page without clicking away and even then the behavior thereafter seems confusing -- sometimes it does, sometimes it doesn't.

EDIT: turns out ^ was because of all the AJAX calls, which are removed in #91 so all is fine, exactly per:

Additionally, tho probably in a separate PR, we will want to merge the partials back into the default.htm in a variety of components now that they have no reason to be loaded async (thereby saving more http requests)