### PR TITLE
Allow all team members to upload match replays

### DIFF
--- a/plugins/rikki/heroeslounge/components/managematches/default.htm
+++ b/plugins/rikki/heroeslounge/components/managematches/default.htm
@@ -4,7 +4,7 @@
 <div class="row mb-3">
     {% endif %} 
     {% if match.wbp == null %}
-    {% if __SELF__.user.sloth.is_captain or __SELF__.user.sloth.is_divs_captain %}
+    {% if __SELF__.user.sloth.isCaptain(__SELF__.team) %}
     {% component 'scheduleMatch' class="mb-3"  id=match.id %}
     {% endif %}
     {% else %} 

--- a/plugins/rikki/heroeslounge/components/managematches/default.htm
+++ b/plugins/rikki/heroeslounge/components/managematches/default.htm
@@ -3,8 +3,10 @@
 {% for match in __SELF__.matches %} {% if loop.index0 is even %}
 <div class="row mb-3">
     {% endif %} 
-    {% if match.wbp == null %} 
-    {% component 'scheduleMatch' class="mb-3"  id=match.id %} 
+    {% if match.wbp == null %}
+    {% if __SELF__.user.sloth.is_captain or __SELF__.user.sloth.is_divs_captain %}
+    {% component 'scheduleMatch' class="mb-3"  id=match.id %}
+    {% endif %}
     {% else %} 
     {%  component 'updateMatch' class="mb-3" id=match.id %}
     {% endif %} 

--- a/plugins/rikki/heroeslounge/components/manageteam/default.htm
+++ b/plugins/rikki/heroeslounge/components/manageteam/default.htm
@@ -1,4 +1,4 @@
-{% if (__SELF__.user.sloth.is_captain == 1 and __SELF__.user.sloth.team_id == __SELF__.team.id) or (__SELF__.user.sloth.is_divs_captain == 1 and __SELF__.user.sloth.divs_team_id == __SELF__.team.id) %}
+{% if __SELF__.user.sloth.isCaptain(__SELF__.team) %}
 <nav class="navbar navbar-expand-lg navbar-light col-12">
     <div class="navbar-header">
         <a class="navbar-brand d-lg-none">Manage Team</a>

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -177,10 +177,15 @@ class Sloth extends Model
     public function isCaptain($team)
     {
         if ($team->type == 1) {
-            return $this->is_captain;
+            if ($team->id == $this->team_id) {
+                return $this->is_captain;
+            }
         } else {
-            return $this->is_divs_captain;
+            if ($team->id == $this->divs_team_id) {
+                return $this->is_divs_captain;
+            }
         }
+        return false;
     }
     
     public function afterCreate()

--- a/plugins/rikki/loungeviews/components/sidenav/default.htm
+++ b/plugins/rikki/loungeviews/components/sidenav/default.htm
@@ -28,12 +28,11 @@
                     {{user.sloth.team.slug}}
                 </a>
                 <ul class="collapse list-unstyled" id="teamMenu">
-                {% if user.sloth.is_captain == true %}
                     <li>
-                        <a href="{{ 'team/manage' | page({slug: user.sloth.team.slug}) }}" title="Manage {{user.sloth.team.title}}">
-                        <i class="fa fa-cogs" aria-hidden="true"></i>
-                        Manage
-                    </a>
+                        <a href="{{'team/view' | page({slug: user.sloth.team.slug}) }}">
+                            <i class="fa fa-eye" aria-hidden="true"></i>
+                                View
+                        </a>
                     </li>
                     <li>
                         <a href="{{ 'team/manageMatch' | page({slug: user.sloth.team.slug}) }}" title="Manage Matches">
@@ -41,19 +40,14 @@
                             Matches
                         </a>
                     </li>
+                {% if user.sloth.is_captain %}
                     <li>
-                        <a href="{{'team/view' | page({slug: user.sloth.team.slug}) }}">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
-                                View
-                        </a>
+                        <a href="{{ 'team/manage' | page({slug: user.sloth.team.slug}) }}" title="Manage {{user.sloth.team.title}}">
+                        <i class="fa fa-cogs" aria-hidden="true"></i>
+                        Manage
+                    </a>
                     </li>
                 {% else %}
-                    <li>
-                        <a href="{{'team/view' | page({slug: user.sloth.team.slug}) }}">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
-                            View
-                        </a>
-                    </li>
                     <li>
                         <a role="button" href="" data-toggle="modal" data-target="#leaveTeamModal">
                             <i class="fa fa-ban" aria-hidden="true"></i>
@@ -71,12 +65,11 @@
                     {{user.sloth.divs_team.slug}}
                 </a>
                 <ul class="collapse list-unstyled" id="divsTeamMenu">
-                {% if user.sloth.is_divs_captain == true %}
                     <li>
-                        <a href="{{ 'team/manage' | page({slug: user.sloth.divs_team.slug}) }}" title="Manage {{user.sloth.divs_team.title}}">
-                        <i class="fa fa-cogs" aria-hidden="true"></i>
-                        Manage
-                    </a>
+                        <a href="{{'team/view' | page({slug: user.sloth.divs_team.slug}) }}">
+                            <i class="fa fa-eye" aria-hidden="true"></i>
+                            View
+                        </a>
                     </li>
                     <li>
                         <a href="{{ 'team/manageMatch' | page({slug: user.sloth.divs_team.slug}) }}" title="Manage Matches">
@@ -84,19 +77,14 @@
                             Matches
                         </a>
                     </li>
+                {% if user.sloth.is_divs_captain %}
                     <li>
-                        <a href="{{'team/view' | page({slug: user.sloth.divs_team.slug}) }}">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
-                                View
-                        </a>
+                        <a href="{{ 'team/manage' | page({slug: user.sloth.divs_team.slug}) }}" title="Manage {{user.sloth.divs_team.title}}">
+                        <i class="fa fa-cogs" aria-hidden="true"></i>
+                        Manage
+                    </a>
                     </li>
-                {% else %}
-                    <li>
-                        <a href="{{'team/view' | page({slug: user.sloth.divs_team.slug}) }}">
-                            <i class="fa fa-eye" aria-hidden="true"></i>
-                            View
-                        </a>
-                    </li>
+                {% else %}  
                     <li>
                         <a role="button" href="" data-toggle="modal" data-target="#leaveDivSTeamModal">
                             <i class="fa fa-ban" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #10 
Enables the `Matches` option for all team members in the left sidebar navigation. Also moved the views / manage options outside of the conditional to remove duplicates.