### PR TITLE
api matches for today or date with timezone

### DIFF
--- a/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
+++ b/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
@@ -6,7 +6,7 @@ use Session;
 
 class TimezoneHelper
 {
-    private const DEFAULT_TIMEZONE = 'UTC';
+    public const DEFAULT_TIMEZONE = 'UTC';
     private const TIMEZONE_KEY = 'timezone';
 
     private static $defaultTimezone;

--- a/plugins/rikki/heroeslounge/routes.php
+++ b/plugins/rikki/heroeslounge/routes.php
@@ -31,9 +31,9 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::get('matches/withApprovedCastBetween/{startdate}/{enddate}','Rikki\Heroeslounge\Http\Match@withApprovedCastBetween');
     Route::get('matches/{id}/games','Rikki\Heroeslounge\Http\Match@games');
     Route::get('matches/{id}/replays','Rikki\Heroeslounge\Http\Match@replays');
-    Route::get('matches/today','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
-    
-    
+    Route::get('matches/{date}/{tz1}/{tz2?}','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
+    Route::get('matches/{date}','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
+
     Route::resource('matches', 'Rikki\Heroeslounge\Http\Match');
     Route::get('matchesAll','Rikki\Heroeslounge\Http\Match@indexAll');
     Route::resource('channel', 'Rikki\Heroeslounge\Http\Twitchchannel');


### PR DESCRIPTION
Resolves #40 

http://localhost:8080/hl/api/v1/matches/today returns matches occurring today in default timezone (UTC, server time) -- same as before (well, since server timezone changed from Berlin to UTC, at any rate...)
http://localhost:8080/hl/api/v1/matches/today/Asia/Tokyo returns matches "today" in a given timezone (here Asia/Tokyo)
http://localhost:8080/hl/api/v1/matches/2019-04-03/Asia/Tokyo returns matches for a specific date in a given timezone (here Asia/Tokyo)
http://localhost:8080/hl/api/v1/matches/2019-04-03 returns matches for a specific date in default timezone (UTC)

http://localhost:8080/hl/api/v1/matches/2019-04-03/America/New_York is same idea, different timezone
http://localhost:8080/hl/api/v1/matches/today/UTC is still valid when someone wants to be explicit
http://localhost:8080/hl/api/v1/matches/2019-04-03/UTC is same idea, now explicitly UTC for a specific date