### PR TITLE
default season for sloth and team stats plus participated seasons

### DIFF
--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -103,6 +103,18 @@ class Match extends Model
         return $this->channels->count() > 0 ? $this->channels->first() : null;
     }
 
+    public function getSeasonAttribute()
+    {
+        if ($this->division != null && $this->division->season != null) {
+            return $this->division->season;
+        } elseif ($this->playoff != null && $this->playoff->season != null) {
+            return $this->playoff->season;
+        } elseif ($this->division != null && $this->division->playoff != null && $this->division->playoff->season != null) {
+            return $this->division->playoff->season;
+        }
+        return null;
+    }
+
     public function getCasterIds()
     {
         return $this->casters
@@ -143,18 +155,7 @@ class Match extends Model
 
     public function belongsToSeason($season)
     {
-        return (($this->division != null && $this->division->season != null && $this->division->season->id == $season->id)
-            || ($this->playoff != null && $this->playoff->season != null && $this->playoff->season->id == $season->id)
-            || ($this->division != null && $this->division->playoff != null && $this->division->playoff->season != null && $this->division->playoff->season->id == $season->id));
-    }
-
-    public function associatedSeasons()
-    {
-        return [
-            $this->division != null ? $this->division->season : null,
-            $this->playoff != null ? $this->playoff->season : null,
-            $this->division != null && $this->division->playoff != null ? $this->division->playoff->season : null
-        ];
+        return $this->season && $this->season->id == $season->id;
     }
 
     public function beforeUpdate()

--- a/plugins/rikki/heroeslounge/models/Match.php
+++ b/plugins/rikki/heroeslounge/models/Match.php
@@ -5,8 +5,8 @@ use Illuminate\Support\Facades\DB;
 use October\Rain\Database\Model;
 use Rikki\Heroeslounge\Models\Timeline;
 use October\Rain\Exception\SystemException;
-use Rikki\Heroeslounge\classes\hotfixes as hotfixes;
-use Rikki\Heroeslounge\Models\Season as Season;
+use Rikki\Heroeslounge\classes\hotfixes;
+use Rikki\Heroeslounge\Models\Season;
 use Rikki\Heroeslounge\Models\Playoff;
 use Rikki\Heroeslounge\Models\Team;
 use Carbon\Carbon;
@@ -148,6 +148,14 @@ class Match extends Model
             || ($this->division != null && $this->division->playoff != null && $this->division->playoff->season != null && $this->division->playoff->season->id == $season->id));
     }
 
+    public function associatedSeasons()
+    {
+        return [
+            $this->division != null ? $this->division->season : null,
+            $this->playoff != null ? $this->playoff->season : null,
+            $this->division != null && $this->division->playoff != null ? $this->division->playoff->season : null
+        ];
+    }
 
     public function beforeUpdate()
     {

--- a/plugins/rikki/loungestatistics/components/SlothStatistics.php
+++ b/plugins/rikki/loungestatistics/components/SlothStatistics.php
@@ -59,6 +59,13 @@ class SlothStatistics extends ComponentBase
             return $a->created_at > $b->created_at ? 1 : -1;
         });
 
+        if ($this->selectedSeason == null) {
+            $participatedSeasonsCount = count($this->participatedSeasons);
+            if ($participatedSeasonsCount > 0) {
+                $this->selectedSeason = $this->participatedSeasons[$participatedSeasonsCount - 1];
+            }
+        }
+
         $this->calculateStats($this->selectedSeason);
     }
 

--- a/plugins/rikki/loungestatistics/components/TeamStatistics.php
+++ b/plugins/rikki/loungestatistics/components/TeamStatistics.php
@@ -56,6 +56,13 @@ class TeamStatistics extends ComponentBase
             return $a->created_at > $b->created_at ? 1 : -1;
         });
 
+        if ($this->selectedSeason == null) {
+            $participatedSeasonsCount = count($this->participatedSeasons);
+            if ($participatedSeasonsCount > 0) {
+                $this->selectedSeason = $this->participatedSeasons[$participatedSeasonsCount - 1];
+            }
+        }
+
         $this->calculateStats($this->selectedSeason);
     }
 

--- a/plugins/rikki/loungestatistics/components/slothstatistics/default.htm
+++ b/plugins/rikki/loungestatistics/components/slothstatistics/default.htm
@@ -32,10 +32,10 @@ Displaying stats of
             });
         jQuery('.dataTables_wrapper').removeClass('container-fluid');">
 <select name="season_id">
-  {% for season in __SELF__.allseasons %}
-  <option value="{{season.id}}">{{season.title}}</option>
+  {% for season in __SELF__.participatedSeasons %}
+  <option value="{{season.id}}"{% if __SELF__.selectedSeason.id==season.id%}selected="selected"{%endif%}>{{season.title}}</option>
   {% endfor %}
-  <option  value="-1" >all time</option>
+  <option value="-1" >all time</option>
 </select>
 <button type="submit">Update</button>
 </form>
@@ -82,5 +82,4 @@ Displaying stats of
     });
 
 </script>
-
 {% endput %}

--- a/plugins/rikki/loungestatistics/components/teamstatistics/default.htm
+++ b/plugins/rikki/loungestatistics/components/teamstatistics/default.htm
@@ -20,10 +20,10 @@ Displaying stats of
                                    info: false
                                });">
 <select name="season_id">
-  {% for season in __SELF__.allseasons %}
-  <option value="{{season.id}}">{{season.title}}</option>
+  {% for season in __SELF__.participatedSeasons %}
+  <option value="{{season.id}}"{% if __SELF__.selectedSeason.id==season.id%}selected="selected"{%endif%}>{{season.title}}</option>
   {% endfor %}
-  <option  value="-1" >all time</option>
+  <option value="-1" >all time</option>
 </select>
 <button type="submit">Update</button>
 </form>


### PR DESCRIPTION
Resolves #50 

I would like extra testing from others because I'm not sure I have good examples in my local db to verify this is working -- specifically the active season handling, as well as verifying belongsToSeason refactor.

In addition / alternatively. I'd like some guidance on setting up my local env for testing this properly, if you could add details here:
https://github.com/Fabian-Sommer/HeroesLounge/wiki/Add-Active-Season-with-Played-Matches-for-Teams-and-Sloths
