### PR TITLE
Enhance API endpoints

### DIFF
--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -83,7 +83,7 @@ class Match extends Controller
         return $retVal;
     }
 
-    private function formatTimezone($tz1, $tz2)
+    private static function formatTimezone($tz1, $tz2)
     {
         if ($tz2) {
             return $tz1 . '/' . $tz2;
@@ -92,31 +92,23 @@ class Match extends Controller
         }
     }
 
-    private function getMatchesForDate($start, $isPlayed)
+    private static function getDbDateMatches($start)
     {
         // Convert to default/server timezone for db query
         $start->setTime(0,0,0)->setTimezone(TimezoneHelper::DEFAULT_TIMEZONE);
         $end = $start->copy()->addDay();
 
-        if (!$isPlayed) {
-            return MatchModel::whereBetween('wbp', [$start, $end])->where('is_played',false)->get();
-        } else {
-            return MatchModel::whereBetween('wbp', [$start, $end])->get();
-        }
+        return MatchModel::whereBetween('wbp', [$start, $end])->where('is_played',false)->get();
     }
 
-    public function getTodaysMatches($tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
+    public function getMatchesForToday($tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        $date = Carbon::today(Self::formatTimezone($tz1, $tz2));
-
-        return getMatchesByDate($date, false);
+        return self::getDbDateMatches(Carbon::today(self::formatTimezone($tz1, $tz2)));
     }
 
-    public function getMatchesByDate($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
+    public function getMatchesForDate($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        $date = Carbon::createFromFormat('Y-m-d', $date, Self::formatTimezone($tz1, $tz2));
-
-        return getMatchesByDate($date);
+        return self::getDbDateMatches(Carbon::createFromFormat('Y-m-d', $date, self::formatTimezone($tz1, $tz2)));
     }
 
     public function caster($id)

--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -23,6 +23,11 @@ class Match extends Controller
         return MatchModel::all();
     }
 
+    public function channels($id)
+    {
+        return MatchModel::findOrFail($id)->channels;
+    }
+
     public function teams($id)
     {
         return MatchModel::findOrFail($id)->teams;

--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -78,7 +78,7 @@ class Match extends Controller
         return $retVal;
     }
 
-    public function getTodaysMatches($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
+    public function getTodaysMatches($tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
         if ($tz2) {
             $timezone = $tz1 . '/' . $tz2;
@@ -86,17 +86,28 @@ class Match extends Controller
             $timezone = $tz1;
         }
 
-        // get today in a given timezone
-        if ($date == 'today') {
-            $start = Carbon::today($timezone);
-        } else {
-            $start = Carbon::createFromFormat('Y-m-d', $date, $timezone);
-        }
+        $start = Carbon::today($timezone);
 
         // now convert back to default/server timezone for db query
         $start->setTime(0,0,0)->setTimezone(TimezoneHelper::DEFAULT_TIMEZONE);
         $end = $start->copy()->addDay();
         return MatchModel::whereBetween('wbp', [$start, $end])->where('is_played',false)->get();
+    }
+
+    public function getMatchesByDate($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
+    {
+        if ($tz2) {
+            $timezone = $tz1 . '/' . $tz2;
+        } else {
+            $timezone = $tz1;
+        }
+
+        $start = Carbon::createFromFormat('Y-m-d', $date, $timezone);
+
+        // now convert back to default/server timezone for db query
+        $start->setTime(0,0,0)->setTimezone(TimezoneHelper::DEFAULT_TIMEZONE);
+        $end = $start->copy()->addDay();
+        return MatchModel::whereBetween('wbp', [$start, $end])->get();
     }
 
     public function caster($id)

--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -6,6 +6,8 @@ use Rikki\Heroeslounge\Models\Game as GameModel;
 use Log;
 use Carbon\Carbon;
 use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
+use InvalidArgumentException;
+use Response;
 
 /**
  * Match Back-end Controller
@@ -107,14 +109,22 @@ class Match extends Controller
 
     public function getMatchesForToday($tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        $start = Carbon::today(self::formatTimezone($tz1, $tz2));
-        return self::getDbDayMatches($start, true);
+        try {
+            $start = Carbon::today(self::formatTimezone($tz1, $tz2));
+            return self::getDbDayMatches($start, true);
+        } catch (InvalidArgumentException $e) {
+            return Response::make('Invalid timezone: ' . $e->getMessage(), 400);
+        }
     }
 
     public function getMatchesForDate($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        $start = Carbon::createFromFormat('Y-m-d', $date, self::formatTimezone($tz1, $tz2));
-        return self::getDbDayMatches($start, false);
+        try {
+            $start = Carbon::createFromFormat('Y-m-d', $date, self::formatTimezone($tz1, $tz2));
+            return self::getDbDayMatches($start, false);
+        } catch (InvalidArgumentException $e) {
+            return Response::make('Invalid date or timezone: ' . $e->getMessage(), 400);
+        }
     }
 
     public function caster($id)

--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -92,23 +92,29 @@ class Match extends Controller
         }
     }
 
-    private static function getDbDateMatches($start)
+    private static function getDbDayMatches($start, $isWithNotPlayed)
     {
         // Convert to default/server timezone for db query
         $start->setTime(0,0,0)->setTimezone(TimezoneHelper::DEFAULT_TIMEZONE);
         $end = $start->copy()->addDay();
 
-        return MatchModel::whereBetween('wbp', [$start, $end])->where('is_played',false)->get();
+        if ($isWithNotPlayed) {
+            return MatchModel::whereBetween('wbp', [$start, $end])->where('is_played',false)->get();
+        } else {
+            return MatchModel::whereBetween('wbp', [$start, $end])->get();
+        }
     }
 
     public function getMatchesForToday($tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        return self::getDbDateMatches(Carbon::today(self::formatTimezone($tz1, $tz2)));
+        $start = Carbon::today(self::formatTimezone($tz1, $tz2));
+        return self::getDbDayMatches($start, true);
     }
 
     public function getMatchesForDate($date, $tz1 = TimezoneHelper::DEFAULT_TIMEZONE, $tz2 = "")
     {
-        return self::getDbDateMatches(Carbon::createFromFormat('Y-m-d', $date, self::formatTimezone($tz1, $tz2)));
+        $start = Carbon::createFromFormat('Y-m-d', $date, self::formatTimezone($tz1, $tz2));
+        return self::getDbDayMatches($start, false);
     }
 
     public function caster($id)

--- a/plugins/rikki/heroeslounge/routes.php
+++ b/plugins/rikki/heroeslounge/routes.php
@@ -31,8 +31,8 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::get('matches/withApprovedCastBetween/{startdate}/{enddate}','Rikki\Heroeslounge\Http\Match@withApprovedCastBetween');
     Route::get('matches/{id}/games','Rikki\Heroeslounge\Http\Match@games');
     Route::get('matches/{id}/replays','Rikki\Heroeslounge\Http\Match@replays');
-    Route::get('matches/{date}/{tz1}/{tz2?}','Rikki\Heroeslounge\Http\Match@getTodaysMatches')->where('date', 'today|\d{4}-\d{2}-\d{2}');
-    Route::get('matches/{date}','Rikki\Heroeslounge\Http\Match@getTodaysMatches')->where('date', 'today|\d{4}-\d{2}-\d{2}');
+    Route::get('matches/today/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
+    Route::get('matches/byDate/{date}/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getMatchesByDate');
 
     Route::resource('matches', 'Rikki\Heroeslounge\Http\Match');
     Route::get('matchesAll','Rikki\Heroeslounge\Http\Match@indexAll');

--- a/plugins/rikki/heroeslounge/routes.php
+++ b/plugins/rikki/heroeslounge/routes.php
@@ -33,6 +33,7 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::get('matches/{id}/replays','Rikki\Heroeslounge\Http\Match@replays');
     Route::get('matches/today/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
     Route::get('matches/byDate/{date}/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getMatchesByDate');
+    Route::get('matches/{id}/channels', 'Rikki\Heroeslounge\Http\Match@channels');
 
     Route::resource('matches', 'Rikki\Heroeslounge\Http\Match');
     Route::get('matchesAll','Rikki\Heroeslounge\Http\Match@indexAll');

--- a/plugins/rikki/heroeslounge/routes.php
+++ b/plugins/rikki/heroeslounge/routes.php
@@ -31,8 +31,8 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::get('matches/withApprovedCastBetween/{startdate}/{enddate}','Rikki\Heroeslounge\Http\Match@withApprovedCastBetween');
     Route::get('matches/{id}/games','Rikki\Heroeslounge\Http\Match@games');
     Route::get('matches/{id}/replays','Rikki\Heroeslounge\Http\Match@replays');
-    Route::get('matches/today/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getTodaysMatches');
-    Route::get('matches/byDate/{date}/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getMatchesByDate');
+    Route::get('matches/today/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getMatchesForToday');
+    Route::get('matches/forDate/{date}/{tz1?}/{tz2?}','Rikki\Heroeslounge\Http\Match@getMatchesForDate');
     Route::get('matches/{id}/channels', 'Rikki\Heroeslounge\Http\Match@channels');
 
     Route::resource('matches', 'Rikki\Heroeslounge\Http\Match');


### PR DESCRIPTION
Refactored the new match date endpoints.
Add the match channels endpoint to get the Twitch channels associated with a match.

Regarding the timezone code, do we want to add some validating for the input options? We don't do any checking of the data inputs or timezone validation. (That it exists as zone or region/city)