### PR TITLE
Backend update captain

### DIFF
--- a/plugins/rikki/heroeslounge/components/ManageTeam.php
+++ b/plugins/rikki/heroeslounge/components/ManageTeam.php
@@ -231,12 +231,10 @@ class ManageTeam extends ComponentBase
         $currentCaptain->pivot->is_captain = false;
         $currentCaptain->pivot->save();
 
-        // // Promote user to captain
+        // Promote user to captain
         $slothToPromote = $this->team->sloths->where('title', post('promote'))->first();
         $slothToPromote->pivot->is_captain = true;
         $slothToPromote->pivot->save();
-        $slothToPromote->addDiscordCaptainRole();
-        $slothToPromote->save();
         
         Flash::success($slothToPromote->title.' has been promoted to Captain');
         return Redirect::to('/team/view/'.$this->team->slug);

--- a/plugins/rikki/heroeslounge/controllers/Team.php
+++ b/plugins/rikki/heroeslounge/controllers/Team.php
@@ -70,5 +70,20 @@ class Team extends Controller
         }
     }
 
+    public function onRelationManagePivotUpdate($model) {
+        $data = post();
+        $team = TeamModel::find($model);
+
+        foreach ($team->sloths as $sloth) {
+            if ($sloth->pivot->sloth_id == $data['manage_id']) {
+                $sloth->pivot->is_captain = $data['Sloth']['pivot']['is_captain'];
+                $sloth->pivot->save();
+
+                /*
+                    Add Discord captain updating logic here.
+                */
+            }
+        }
+    }
 
 }

--- a/plugins/rikki/heroeslounge/controllers/Team.php
+++ b/plugins/rikki/heroeslounge/controllers/Team.php
@@ -46,8 +46,14 @@ class Team extends Controller
         if($dis == true) {
             $team = $model;
             $team->sloths->each(function($sloth) use ($team) {
+                $isCaptain = $sloth->isCaptain();
+
                 $sloth->teams()->remove($team);
                 $sloth->save();
+
+                if ($isCaptain != $sloth->isCaptain()) {
+                    $sloth->removeDiscordCaptainRole();
+                }
 
             });
             $team->divisions->each(function($d) use(&$team) {

--- a/plugins/rikki/heroeslounge/controllers/Team.php
+++ b/plugins/rikki/heroeslounge/controllers/Team.php
@@ -48,7 +48,7 @@ class Team extends Controller
             $team->sloths->each(function($sloth) use ($team) {
                 $isCaptain = $sloth->isCaptain();
 
-                $sloth->teams()->remove($team);
+                $sloth->teams()->detach($team);
                 $sloth->save();
 
                 if ($isCaptain != $sloth->isCaptain()) {
@@ -67,22 +67,6 @@ class Team extends Controller
 
             });
             $team->seasons()->detach();
-        }
-    }
-
-    public function onRelationManagePivotUpdate($model) {
-        $data = post();
-        $team = TeamModel::find($model);
-
-        foreach ($team->sloths as $sloth) {
-            if ($sloth->pivot->sloth_id == $data['manage_id']) {
-                $sloth->pivot->is_captain = $data['Sloth']['pivot']['is_captain'];
-                $sloth->pivot->save();
-
-                /*
-                    Add Discord captain updating logic here.
-                */
-            }
         }
     }
 

--- a/plugins/rikki/heroeslounge/controllers/team/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/team/config_relation.yaml
@@ -59,15 +59,11 @@ sloths:
         list:
             columns:
                 title:
-                    label: title
+                    label: User
                     searchable: true
                 pivot[is_captain]:
-                    label: Captain
+                    label: Is Captain
                     type: switch
-                teams:
-                    label: Teams
-                    relation: teams
-                    select: title
         toolbarButtons: add|remove
     manage:
         showSearch: true
@@ -85,3 +81,4 @@ sloths:
                     type: checkbox
                     default: false
                     span: right
+                    

--- a/plugins/rikki/heroeslounge/controllers/team/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/team/config_relation.yaml
@@ -81,4 +81,3 @@ sloths:
                     type: checkbox
                     default: false
                     span: right
-                    

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -110,7 +110,8 @@ class Sloth extends Model
             'key' => 'sloth_id',
             'otherKey' => 'team_id',
             'table' => 'rikki_heroeslounge_sloth_team',
-            'pivot' => ['is_captain']
+            'pivot' => ['is_captain'],
+            'pivotModel' => 'Rikki\Heroeslounge\Models\SlothTeamPivot'
         ],
     ];
 

--- a/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
+++ b/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
@@ -1,0 +1,45 @@
+<?php namespace Rikki\Heroeslounge\Models;
+
+use October\Rain\Database\Pivot;
+use Rikki\Heroeslounge\Models\Sloth;
+use Rikki\Heroeslounge\Models\Team;
+
+/**
+ * Sloth-Team Pivot Model
+ */
+class SlothTeamPivot extends Pivot
+{
+    
+    /*
+     * Disable timestamps by default.
+     * Remove this line if timestamps are defined in the database table.
+     */
+    public $timestamps = false;
+
+    /**
+     * @var string The database table used by the model.
+     */
+    public $table = 'rikki_heroeslounge_sloth_team';
+
+    public function afterDelete()
+    {
+        /*
+            I was hoping this would fire when a team gets disbanded, but it doesn't.
+        */
+    }
+
+    public function afterSave()
+    {
+        if ($this->isDirty('is_captain')) {
+            $team = Team::find($this->team_id);
+            $sloth = Sloth::find($this->sloth_id);
+
+            if ($sloth->isCaptainOfTeam($team)) {
+                $sloth->addDiscordCaptainRole();
+            } else if (!$sloth->isCaptain()) {
+                $sloth->removeDiscordCaptainRole();
+            }
+        }
+    }
+
+}

--- a/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
+++ b/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
@@ -24,27 +24,24 @@ class SlothTeamPivot extends Pivot
     public function afterSave()
     {
         if ($this->isDirty('is_captain')) {
-            $sloth = Sloth::find($this->sloth_id);
-            $noLongerCaptain = false;
-
-            if ($sloth->teams->count() <= 1) {
-                $noLongerCaptain = true;
-            } else {
-                $isCaptain = $sloth->teams->first(function($index, $team) {
-                    return $team->id != $this->team_id && $team->pivot->is_captain;
-                });
-
-                if ($isCaptain != null) {
-                    $noLongerCaptain = true;
-                }
-            }
+            $sloth = Sloth::find($this->sloth_id);            
 
             if ($this->is_captain) {
                 $sloth->addDiscordCaptainRole();
-            } else if (!$this->is_captain && $noLongerCaptain) {
-                $sloth->removeDiscordCaptainRole();
+            } else {
+                if(!isCaptainOfOtherTeam ($sloth, $this->team_id)) {
+                    $sloth->removeDiscordCaptainRole();
+                }
             }
         }
+    }
+
+    public function isCaptainOfOtherTeam ($sloth, $updatedTeamId) {
+        $teamsCaptainOf = $sloth->teams->filter(function($index, $team) {
+            return $team->id != $updatedTeamId && $team->pivot->is_captain;
+        });
+
+        return $teamsCaptainOf->count() >= 1;
     }
 
 }

--- a/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
+++ b/plugins/rikki/heroeslounge/models/SlothTeamPivot.php
@@ -29,19 +29,16 @@ class SlothTeamPivot extends Pivot
             if ($this->is_captain) {
                 $sloth->addDiscordCaptainRole();
             } else {
-                if(!isCaptainOfOtherTeam ($sloth, $this->team_id)) {
+                if(!$this->isCaptainOfOtherTeam($sloth, $this->team_id)) {
                     $sloth->removeDiscordCaptainRole();
                 }
             }
         }
     }
 
-    public function isCaptainOfOtherTeam ($sloth, $updatedTeamId) {
-        $teamsCaptainOf = $sloth->teams->filter(function($index, $team) {
+    public function isCaptainOfOtherTeam($sloth, $updatedTeamId) {
+        return $sloth->teams->contains(function($team) use ($updatedTeamId) {
             return $team->id != $updatedTeamId && $team->pivot->is_captain;
         });
-
-        return $teamsCaptainOf->count() >= 1;
     }
-
 }

--- a/plugins/rikki/heroeslounge/models/Team.php
+++ b/plugins/rikki/heroeslounge/models/Team.php
@@ -76,6 +76,7 @@ class Team extends Model
             'otherKey' => 'sloth_id',
             'table' => 'rikki_heroeslounge_sloth_team',
             'pivot' => ['is_captain'],
+            'pivotModel' => 'Rikki\Heroeslounge\Models\SlothTeamPivot'
         ],
         'divisions' =>
         [


### PR DESCRIPTION
Started on the backend team captain management and captains of disbanding teams. I'm not entirely happy with how the sync is done with Discord when a team disbands, but it works.

Out of the box the team captain pivot data updates fine, but to incorporate the Discord captain role management I'm trying to use `onRelationManagePivotUpdate()` in the team controller. However when I add this listener it requires me to implement the entire pivot data update process and when changing the captain. a refresh is needed before the form view displays the made changes.

I'm not sure this is the right way to go about things, and any pointers would be great.