### PR TITLE
Use the playoff title for matches in calendar

### DIFF
--- a/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
+++ b/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
@@ -21,7 +21,15 @@
                         [{{match.teams[0].region.title}}]
                         {% endif %}
                     </span>
-                    <span title="{{match.division.title}}" class="hideOverflow">{{match.division.title}}</span>
+                    <span class="hideOverflow">
+                        {% if match.division.playoff is not null %}
+                        {{match.division.playoff.title}}
+                        {% elseif match.playoff is not null %}
+                        {{match.playoff.title}}
+                        {% else %}
+                        {{match.division.title}}
+                        {% endif %}
+                    </span>
                     <span>@{{match.wbp | date(__SELF__.timeFormat, __SELF__.timezone)}}</span>
                     {%  for channel in match.channels  %}
                     <span class="event-list--time facebook">


### PR DESCRIPTION
Uses the playoff title for upcoming matches instead of the division title for matches that belong to a playoff.

Fixes #124 