### PR TITLE
Sloth teams visibile on profile and backend

### DIFF
--- a/plugins/rikki/heroeslounge/Plugin.php
+++ b/plugins/rikki/heroeslounge/Plugin.php
@@ -319,6 +319,12 @@ class Plugin extends PluginBase
                     'label' => 'Website URL',
                     'tab' => 'Sloth',
                     'type' => 'text'
+                ],
+                'sloth[teams]' => [
+                    'label' => 'Teams',
+                    'type' => 'relation',
+                    'nameFrom' => 'title',
+                    'tab' => 'Teams'
                 ]
             ]);
         });

--- a/plugins/rikki/loungeviews/components/divisionoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/divisionoverview/default.htm
@@ -12,23 +12,25 @@ Unknown Division
 <div class="row">
     <div class="col-md-8">
         <div class="col-md-12">
-           {% component 'divisionTable' id=__SELF__.div.id %}
+            {% component 'divisionTable' id=__SELF__.div.id %}
         </div>
         {% if __SELF__.div.season.current_round > 0 %}
         <div class="col-md-12">
             <nav class="navbar navbar-expand-lg navbar-light">
                 <a class="navbar-brand">Round</a>
-                <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#{{__SELF__.div.slug}}_rounds"
-                    aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                                    <span class="navbar-toggler-icon"></span>
-                                    </button>
+                <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+                    data-target="#{{__SELF__.div.slug}}_rounds" aria-controls="navbarSupportedContent"
+                    aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
                 <div class="collapse navbar-collapse" id="{{__SELF__.div.slug}}_rounds">
                     <ul class="nav nav-tabs mr-auto">
                         {% for key,i in 1..__SELF__.div.season.current_round %}
                         <li class="nav-item">
-                            <a class="nav-link{% if key==0 %} active{% endif %}" data-toggle="tab" href="#round_{{i}}">
-                                            &nbsp;&nbsp;&nbsp;&nbsp;{{i}} &nbsp;&nbsp;&nbsp;&nbsp;
-                                        </a>
+                            <a class="nav-link{% if key==__SELF__.div.season.current_round - 1 %} active{% endif %}"
+                                data-toggle="tab" href="#round_{{i}}">
+                                &nbsp;&nbsp;&nbsp;&nbsp;{{i}} &nbsp;&nbsp;&nbsp;&nbsp;
+                            </a>
                         </li>
                         {% endfor %}
                     </ul>
@@ -36,7 +38,8 @@ Unknown Division
             </nav>
             <div class="tab-content">
                 {% for key,i in 1..__SELF__.div.season.current_round %}
-                <div class="tab-pane{% if key==0 %} active{% endif %}" id="round_{{i}}" role="tabpanel">
+                <div class="tab-pane{% if key==__SELF__.div.season.current_round - 1 %} active{% endif %}"
+                    id="round_{{i}}" role="tabpanel">
                     {% component 'roundMatches' id=__SELF__.div.id round=i %}
                 </div>
                 {% endfor %}
@@ -44,7 +47,7 @@ Unknown Division
         </div>
         {% endif %}
     </div>
- 
+
     <div class="col-md-4 sidebar">
         <h3 class="widget-title">Recent Results</h3>
         {% component 'recentResults' id=__SELF__.div.id %}

--- a/plugins/rikki/loungeviews/components/profile/default.htm
+++ b/plugins/rikki/loungeviews/components/profile/default.htm
@@ -1,26 +1,34 @@
-{% set banner %} {% if __SELF__.sloth.banner %} {{__SELF__.sloth.banner.path}} {% else %} {{'plugins/rikki/heroeslounge/assets/img/bg_CCC.png'
-| app}} {% endif %} {% endset %} {% set avatar %} {% if __SELF__.sloth.user.avatar %} {{__SELF__.sloth.user.avatar.path}}
-{% else %} {{'plugins/rikki/heroeslounge/assets/img/profile-icon.png' | app}} {% endif %} {% endset %} {% set team %} {%
-if __SELF__.sloth.team %}
-<a href="{{ 'team/view' | page({slug: __SELF__.sloth.team.slug})}}">[{{__SELF__.sloth.team.title}}]</a> {% else %} {% endif
-%} {% endset %}
+{% set banner %}
+{% if __SELF__.sloth.banner %} {{__SELF__.sloth.banner.path}} {% else %}
+{{'plugins/rikki/heroeslounge/assets/img/bg_CCC.png'| app}} {% endif %}
+{% endset %}
+{% set avatar %}
+{% if __SELF__.sloth.user.avatar %} {{__SELF__.sloth.user.avatar.path}} {% else %}
+{{'plugins/rikki/heroeslounge/assets/img/profile-icon.png' | app}} {% endif %}
+{% endset %}
+
 {% if user %}
-<div class="jumbotron image-banner banner-custom-header mb-3" style="background:url({{banner}}) no-repeat 0 0 #ffffff;background-size:cover;background-position:center center">
+<div class="jumbotron image-banner banner-custom-header mb-3"
+    style="background:url({{banner}}) no-repeat 0 0 #ffffff;background-size:cover;background-position:center center">
     <div style="background-color:rgba(33,33,33,0.5)" class="wow fadeIn">
         <div class=" d-flex justify-content-center mr-5">
-            <div style="height:110px;width:110px;position:relative; display:inline-block;overflow:hidden" class="wow zoomIn mr-3">
+            <div style="height:110px;width:110px;position:relative; display:inline-block;overflow:hidden"
+                class="wow zoomIn mr-3">
                 <img class="img-fluid rounded" style="position:absolute;top:50%;min-height:100%;display:block;left:50%;-webkit-transform: translate(-50%, -50%);
                                 min-width:100%;" src="{{avatar}}" alt="Logo" title="Logo">
             </div>
             <div class="mr-5">
-                <h1 class="block-title wow zoomIn">{{team}}{{__SELF__.sloth.title}}</h1>
-                <div class="text-center d-xs-none wow zoomIn description" style="visibility: visible; animation-name: zoomIn;">
+                <h1 class="block-title wow zoomIn">{{__SELF__.sloth.title}}</h1>
+                <div class="text-center d-xs-none wow zoomIn description"
+                    style="visibility: visible; animation-name: zoomIn;">
                     <div class="SocialSharingButtons">
                         {% if __SELF__.sloth.twitter_url %}
-                        <a href="{{__SELF__.sloth.twitter_url}}" rel="noopener" target="_blank" title="View Twitter Profile" class="share-btn twitter">
+                        <a href="{{__SELF__.sloth.twitter_url}}" rel="noopener" target="_blank"
+                            title="View Twitter Profile" class="share-btn twitter">
                             <i class="fa fa-twitter" aria-hidden="true"></i>
                         </a> {% endif %} {% if __SELF__.sloth.facebook_url %}
-                        <a href="{{__SELF__.sloth.facebook_url}}" rel="noopener" target="_blank" title="View Facebook Profile" class="share-btn facebook">
+                        <a href="{{__SELF__.sloth.facebook_url}}" rel="noopener" target="_blank"
+                            title="View Facebook Profile" class="share-btn facebook">
                             <i class="fa fa-facebook" aria-hidden="true"></i>
                         </a> {% endif %} {% if __SELF__.sloth.twitch_url %}
                         <a href="{{__SELF__.sloth.twitch_url}}" class="share-btn twitch">
@@ -41,24 +49,48 @@ if __SELF__.sloth.team %}
 
 <div class="card">
     <div class="card-body">
-        {% if __SELF__.sloth.role %} {% set path = 'assets/img/roles/' ~__SELF__.sloth.role.title|replace({' ':'-'})|lower ~ '.svg' %}
+        {% if __SELF__.sloth.role %}
+        {% set path = 'assets/img/roles/' ~__SELF__.sloth.role.title|replace({' ':'-'})|lower ~ '.svg' %}
         <p class="card-text">
-            <img src="{{path | theme}}" class="mr-2 rounded" title="{{__SELF__.sloth.role.title}}" alt="{{__SELF__.sloth.role.title}}"
-                style="max-height:30px;max-width:30px;background-color:#2e93cd" /> {{__SELF__.sloth.role.title}}
+            <img src="{{path | theme}}" class="mr-2 rounded" title="{{__SELF__.sloth.role.title}}"
+                alt="{{__SELF__.sloth.role.title}}" style="max-height:30px;max-width:30px;background-color:#2e93cd" />
+            {{__SELF__.sloth.role.title}}
         </p>
         {% endif %} {% if __SELF__.sloth.battle_tag %}
         <p class="card-text">
-            <img src="{{'assets/img/btns/battlenet.svg' | theme}}" class="mr-2 rounded" title="Battle Tag" alt="Battle Tag" style="max-height:30px;max-width:30px;color:white;background-color:#2e93cd"
-            />{% if  __SELF__.sloth.hotslogs_id %} <a href="https://www.hotslogs.com/Player/Profile?PlayerID={{ __SELF__.sloth.hotslogs_id}}"
-                alt="HotSLogs ID" rel="noopener" target="_blank">{{__SELF__.sloth.battle_tag}}</a> {% else %} {{__SELF__.sloth.battle_tag}} {% endif %}</p>{%
+            <img src="{{'assets/img/btns/battlenet.svg' | theme}}" class="mr-2 rounded" title="Battle Tag"
+                alt="Battle Tag"
+                style="max-height:30px;max-width:30px;color:white;background-color:#2e93cd" />{% if  __SELF__.sloth.hotslogs_id %}
+            <a href="https://www.hotslogs.com/Player/Profile?PlayerID={{ __SELF__.sloth.hotslogs_id}}" alt="HotSLogs ID"
+                rel="noopener" target="_blank">{{__SELF__.sloth.battle_tag}}</a> {% else %}
+            {{__SELF__.sloth.battle_tag}} {% endif %}</p>{%
         endif %} {% if __SELF__.sloth.discord_tag %}
         <p class="card-text">
-            <img src="{{'assets/img/btns/discord.svg' | theme}}" class="mr-2 rounded" title="Discord Tag" alt="Discord Tag" style="max-height:30px;max-width:30px;color:white;background-color:#2e93cd"
-            /> {{__SELF__.sloth.discord_tag}}</p>{% endif %} {% if __SELF__.sloth.user.country_id %}
-        <p class="card-text"><strong>Country:</strong> {{__SELF__.sloth.user.country.name}}</p>{% endif %} {% if __SELF__.sloth.birthday %}
-        <p class="card-text"><strong>Birthday:</strong> {{__SELF__.sloth.birthday}}</p>{% endif %} {% if __SELF__.sloth.short_description %}
-        <p class="card-text"><strong>Description:</strong><br/>{{__SELF__.sloth.short_description}}</p>{% endif %}
+            <img src="{{'assets/img/btns/discord.svg' | theme}}" class="mr-2 rounded" title="Discord Tag"
+                alt="Discord Tag" style="max-height:30px;max-width:30px;color:white;background-color:#2e93cd" />
+            {{__SELF__.sloth.discord_tag}}</p>{% endif %} {% if __SELF__.sloth.user.country_id %}
+        <p class="card-text"><strong>Country:</strong> {{__SELF__.sloth.user.country.name}}</p>{% endif %}
+        {% if __SELF__.sloth.birthday %}
+        <p class="card-text"><strong>Birthday:</strong> {{__SELF__.sloth.birthday}}</p>{% endif %}
+        {% if __SELF__.sloth.short_description %}
+        <p class="card-text"><strong>Description:</strong><br />{{__SELF__.sloth.short_description}}</p>{% endif %}
     </div>
+</div>
+<br>
+<h3>Teams</h3>
+<div class="card">
+    {% for team in __SELF__.sloth.teams %}
+    {% set logo %}
+    {% if team.logo %} {{team.logo}} {% endif %}
+    {% endset %}
+
+    <div class="card-body">
+        <p class="card-text">
+            <img class="img-fluid mr-1 Icon28x" src="{{logo.path | resize(64, 64) }}" alt="Logo" title="Logo">
+            <a href="{{ 'team/view' | page({slug: team.slug})}}">{{team.title}}</a>
+        </p>
+    </div>
+    {% endfor %}
 </div>
 <br>
 <div class="row">


### PR DESCRIPTION
Adds sloth teams listing to the backend and frontend profile page.

I'm not entirely certain if the rescaling of the image is working properly, I couldn't get it to work locally, but copied it off of already existing code (from the division overview recent results).

The backend team list for the user isn't ideal for adding a user to a team, but I think that most moderators use the team backend form for that anyway.