### PR TITLE
Enhance game endpoints

### DIFF
--- a/plugins/rikki/heroeslounge/http/Game.php
+++ b/plugins/rikki/heroeslounge/http/Game.php
@@ -19,6 +19,17 @@ class Game extends Controller
         return GameModel::all();
     }
 
+    public function replay($id)
+    {
+        $game = GameModel::find($id);
+
+        if ($game && $game->replay) {
+            return $game->replay;
+        } else {
+            return 'No replay for game with id ' . $id;
+        }
+    }
+
     public function indexAllWithPlayers()
     {
         $retVal = [];

--- a/plugins/rikki/heroeslounge/http/Match.php
+++ b/plugins/rikki/heroeslounge/http/Match.php
@@ -52,7 +52,8 @@ class Match extends Controller
         $games = MatchModel::find($id)->games;
         $games->each(function($g) use(&$retVal)
         {
-            $gameData = ['Team One' => ($g->teamOne != null ? $g->teamOne->title : $g->match->teams[0]->title),
+            $gameData = ['id' => $g->id,
+                        'Team One' => ($g->teamOne != null ? $g->teamOne->title : $g->match->teams[0]->title),
                          'Team Two' => ($g->teamTwo != null ? $g->teamTwo->title : $g->match->teams[1]->title),
                          'Winner' => ($g->winner ? $g->winner->title : 'None'),
                          'Map' => ($g->map ? $g->map->title : 'None'),

--- a/plugins/rikki/heroeslounge/http/game/config_rest.yaml
+++ b/plugins/rikki/heroeslounge/http/game/config_rest.yaml
@@ -12,6 +12,7 @@ allowedActions:
   show:
   update:
   destroy:
+  replay:
 # Model Class name
 modelClass: Rikki\Heroeslounge\Models\Game
 

--- a/plugins/rikki/heroeslounge/routes.php
+++ b/plugins/rikki/heroeslounge/routes.php
@@ -44,6 +44,7 @@ Route::group(['prefix' => 'api/v1'], function () {
     Route::resource('games', 'Rikki\Heroeslounge\Http\Game');
     Route::get('gamesAll','Rikki\Heroeslounge\Http\Game@indexAll');
     Route::get('gamesAllWithPlayers','Rikki\Heroeslounge\Http\Game@indexAllWithPlayers');
+    Route::get('games/{id}/replay', 'Rikki\Heroeslounge\Http\Game@replay');
 
     Route::resource('bans','Rikki\Heroeslounge\Http\Bans');
     Route::get('bansAll','Rikki\Heroeslounge\Http\Bans@indexAll');


### PR DESCRIPTION
Adds the match `id` property to the match games response and allows you to get the replay file information from a specific game with `games/{id}/replay` endpoint.