### PR TITLE
Try to attach sub by heroesprofile_id first

### DIFF
--- a/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
+++ b/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
@@ -319,9 +319,9 @@ class ReplayParsing
                 $participation->hero = $hero;
                 if ($playerDetails["m_teamId"] == 0) {
                     $participation->team_id = $this->match->teams[$firstReplayTeam]->id;
-                    $subSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
-                    if (isset($subSloth)) {
-                        $participation->sloth = $subSloth;
+                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    if (isset($participatingSloth)) {
+                        $participation->sloth = $participatingSloth;
                     } else {
                         $teamKey = array_search(strtolower($playerDetails["m_name"]), $firstTeamNames);
                         if ($teamKey !== false) {
@@ -336,9 +336,9 @@ class ReplayParsing
                     }
                 } elseif ($playerDetails["m_teamId"] == 1) {
                     $participation->team_id = $this->match->teams[$secondReplayTeam]->id;
-                    $subSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
-                    if (isset($subSloth)) {
-                        $participation->sloth = $subSloth;
+                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    if (isset($participatingSloth)) {
+                        $participation->sloth = $participatingSloth;
                     } else {
                         $teamKey = array_search(strtolower($playerDetails["m_name"]), $secondTeamNames);
                         if ($teamKey !== false) {

--- a/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
+++ b/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
@@ -319,28 +319,38 @@ class ReplayParsing
                 $participation->hero = $hero;
                 if ($playerDetails["m_teamId"] == 0) {
                     $participation->team_id = $this->match->teams[$firstReplayTeam]->id;
-                    $teamKey = array_search(strtolower($playerDetails["m_name"]), $firstTeamNames);
-                    if ($teamKey !== false) {
-                        $participation->sloth = $this->match->teams[$firstReplayTeam]->sloths[$teamKey];
+                    $subSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    if (isset($subSloth)) {
+                        $participation->sloth = $subSloth;
                     } else {
-                        //player might be a sub, we got to check all sloths now
-                        $allKey = array_search(strtolower($playerDetails["m_name"]), $this->allSlothNames);
-                        if ($allKey !== false) {
-                            $participation->sloth = Sloth::all()[$allKey];
+                        $teamKey = array_search(strtolower($playerDetails["m_name"]), $firstTeamNames);
+                        if ($teamKey !== false) {
+                            $participation->sloth = $this->match->teams[$firstReplayTeam]->sloths[$teamKey];
+                        } else {
+                            //player might be a sub, we got to check all sloths now
+                            $allKey = array_search(strtolower($playerDetails["m_name"]), $this->allSlothNames);
+                            if ($allKey !== false) {
+                                $participation->sloth = Sloth::all()[$allKey];
+                            }
                         }
                     }
                 } elseif ($playerDetails["m_teamId"] == 1) {
                     $participation->team_id = $this->match->teams[$secondReplayTeam]->id;
-                    $teamKey = array_search(strtolower($playerDetails["m_name"]), $secondTeamNames);
-                    if ($teamKey !== false) {
-                        $participation->sloth = $this->match->teams[$secondReplayTeam]->sloths[$teamKey];
+                    $subSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    if (isset($subSloth)) {
+                        $participation->sloth = $subSloth;
                     } else {
-                        //player might be a sub, we got to check all sloths now
-                        $allKey = array_search(strtolower($playerDetails["m_name"]), $this->allSlothNames);
-                        if ($allKey !== false) {
-                            $participation->sloth = Sloth::all()[$allKey];
+                        $teamKey = array_search(strtolower($playerDetails["m_name"]), $secondTeamNames);
+                        if ($teamKey !== false) {
+                            $participation->sloth = $this->match->teams[$secondReplayTeam]->sloths[$teamKey];
+                        } else {
+                            //player might be a sub, we got to check all sloths now
+                            $allKey = array_search(strtolower($playerDetails["m_name"]), $this->allSlothNames);
+                            if ($allKey !== false) {
+                                $participation->sloth = Sloth::all()[$allKey];
+                            }
                         }
-                    }
+                    }                    
                 }
                 if ($playerDetails["m_result"] == 1 && $modify_winner) {
                     if ($playerDetails["m_teamId"] == 0) {

--- a/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
+++ b/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
@@ -350,7 +350,7 @@ class ReplayParsing
                                 $participation->sloth = Sloth::all()[$allKey];
                             }
                         }
-                    }                    
+                    }
                 }
                 if ($playerDetails["m_result"] == 1 && $modify_winner) {
                     if ($playerDetails["m_teamId"] == 0) {


### PR DESCRIPTION
Resolves #148 for the most part.

This will try to match substitute players by their `heroesprofile_id`, before falling back to matching by their battletag name. As our `heroesprofile_id` data is quite complete, this should prevent wrong sloths being assoicated with games.

This already wasn't a problem for players part of the team on the website , because we initially limit our search to website team members. (And it was really unlikely that people had the same battletag name on the same team)