### PR TITLE
Reduce notifications for users on multiple teams

### DIFF
--- a/plugins/rikki/heroeslounge/classes/helpers/NotificationHelper.php
+++ b/plugins/rikki/heroeslounge/classes/helpers/NotificationHelper.php
@@ -166,11 +166,11 @@ class NotificationHelper
     {
         $registerableSeasons = Seasons::where('is_active', 1)->where('reg_open', 1)->where('region_id', $sloth->region_id)->get();
         foreach ($registerableSeasons as $season) {
-            if ($season->free_agents->contains($sloth->id)) {
+            if ($sloth->seasons->contains($season)) {
                 continue;
             }
 
-            if ($sloth->isSignedUpForSeason($season)) {
+            if ($sloth->isInTeamParticipatingInSeason($season)) {
                 continue;
             }
 
@@ -185,7 +185,7 @@ class NotificationHelper
             if ($sloth->isCaptain()) {
                 $retVal[] = [
                     'type' => 'warning',
-                    'message' => 'You arent\'t listed to participate in '.$season->title.'. You can register as a free agent or you can sign up the team you\'re captain of on the season page!',
+                    'message' => 'You arent\'t listed to participate in '.$season->title.'. You can register as a free agent or you can sign up your team on the season page!',
                     'entity' => $season->toArray()
                 ];
             } else {

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -151,7 +151,7 @@ class Sloth extends Model
 
     //checks if any of this users teams are signed up for the season.
     //Just for signup phase of seasons.
-    public function isSignedUpForSeason($season) {
+    public function isInTeamParticipatingInSeason($season) {
         foreach ($this->teams as $key => $team) {
             if ($team->seasons->contains($season)) {
                 return true;
@@ -173,7 +173,7 @@ class Sloth extends Model
 
     public function mayJoinTeam($team) {
         foreach ($team->seasons as $key => $season) {
-            if ($season->is_active && $this->isSignedUpForSeason($season)) {
+            if ($season->is_active && $this->isInTeamParticipatingInSeason($season)) {
                 return false;
             }
         }

--- a/plugins/rikki/heroeslounge/models/Team.php
+++ b/plugins/rikki/heroeslounge/models/Team.php
@@ -165,7 +165,7 @@ class Team extends Model
     public function isEligibleForSeason($season)
     {
         foreach ($this->sloths as $key => $sloth) {
-            if ($sloth->isSignedUpForSeason($season)) {
+            if ($sloth->isInTeamParticipatingInSeason($season)) {
                 return $sloth;
             }
         }


### PR DESCRIPTION
Fixes #121 I reduced the number of notifications users would receive when they're part of multiple teams and we're checking their participation.

I was unsure if I should limit the `checkRoster` notification to only show when the team is registered for a season. 
If the above is desired, how about adding an additional statement that we'll fill their team when sign ups close.