### PR TITLE
Heroesprofile api update

### DIFF
--- a/plugins/rikki/heroeslounge/classes/hotslogs/IDFetcher.php
+++ b/plugins/rikki/heroeslounge/classes/hotslogs/IDFetcher.php
@@ -55,7 +55,7 @@ class IDFetcher
         
         $sloth->heroesprofile_id = null;
 
-        $url = 'https://www.heroesprofile.com/API/Profile/?&api_key=' . AuthCode::getHeroesProfileKey() . '&battletag=' . urlencode($battletag) . '&region=' . $region;
+        $url = 'https://api.heroesprofile.com/api/Player?mode=json&api_token=' . AuthCode::getHeroesProfileKey() . '&battletag=' . urlencode($battletag) . '&region=' . $region;
 
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -66,8 +66,8 @@ class IDFetcher
         if ($output != "null") {
             $data = json_decode($output, true);
             if ($data != null) {
-                if (array_key_exists("blizz_id", $data[0])) {
-                    $sloth->heroesprofile_id = $data[0]["blizz_id"];
+                if (array_key_exists("blizz_id", $data)) {
+                    $sloth->heroesprofile_id = $data["blizz_id"];
                 }
             }
         }

--- a/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
+++ b/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
@@ -18,7 +18,7 @@ class MMRFetcher
 
     public static function updateMMRs()
     {
-        $sloths = SlothModel::all()->slice(0, 75);
+        $sloths = SlothModel::all();
 
         foreach ($sloths as $sloth) {
             set_time_limit(30);

--- a/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
+++ b/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
@@ -11,26 +11,18 @@ class MMRFetcher
         $sloths = SlothModel::where('mmr', 0)->get();
 
         foreach ($sloths as $sloth) {
-            set_time_limit(60);
-            $throttleTime = MMRFetcher::updateMMRHeroesProfile($sloth);
-
-            if ($throttleTime > 0) {
-                sleep($throttleTime);
-            }
+            set_time_limit(30);
+            MMRFetcher::updateMMRHeroesProfile($sloth);
         }
     }
 
     public static function updateMMRs()
     {
-        $sloths = SlothModel::all();
+        $sloths = SlothModel::all()->slice(0, 75);
 
         foreach ($sloths as $sloth) {
-            set_time_limit(60);
-            $throttleTime = MMRFetcher::updateMMRHeroesProfile($sloth);
-
-            if ($throttleTime > 0) {
-                sleep($throttleTime);
-            }
+            set_time_limit(30);
+            MMRFetcher::updateMMRHeroesProfile($sloth);
         }
     }
 
@@ -206,11 +198,14 @@ class MMRFetcher
             }
         }
 
-        // Returns the throttle time to wait for the next request.
+        // Check if we've hit the rate-limit and retry the request.
         if (array_key_exists('retry-after', $headers)) {
-            return $headers['retry-after'][0];
-        }
+            $throttleTime = $headers['retry-after'][0];
 
-        return 0;
+            if ($throttleTime > 0) {
+                sleep($throttleTime);
+                MMRFetcher::updateMMRHeroesProfile($sloth);
+            }
+        }
     }
 }

--- a/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
+++ b/plugins/rikki/heroeslounge/classes/mmr/MMRFetcher.php
@@ -130,7 +130,7 @@ class MMRFetcher
         $battletag = $sloth->battle_tag;
         $region = $sloth->getHeroesProfileRegionId();
 
-        $url = 'https://heroesprofile.com/API/MMR/Player/?api_key=' . AuthCode::getHeroesProfileKey() . '&p_b=' . urlencode($battletag) . '&region=' . $region;
+        $url = 'https://api.heroesprofile.com/api/Player/MMR/?mode=json&api_token=' . AuthCode::getHeroesProfileKey() . '&battletag=' . urlencode($battletag) . '&region=' . $region;
 
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Closes #153 In my testing with a subset of our user-base this handled their rate-limit. I increased the `set_time_limit` to 60 to be on the safe side to not let the script time out, as they reset the permitted requests every minute.

We'll need to update our authorization token, as we were required to generate a new one. I can send this to you when you deploy.