### PR TITLE
Add battletag name to heroes profile id matcher

### DIFF
--- a/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
+++ b/plugins/rikki/heroeslounge/classes/replayparsing/ReplayParsing.php
@@ -319,7 +319,11 @@ class ReplayParsing
                 $participation->hero = $hero;
                 if ($playerDetails["m_teamId"] == 0) {
                     $participation->team_id = $this->match->teams[$firstReplayTeam]->id;
-                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    // Retrieve all the sloths with matching Heroes Profile ID and then filter on battletag name.
+                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->get()->first(function ($sloth) use ($playerDetails) {
+                        return strtolower(explode('#', $sloth->battle_tag)[0]) == strtolower($playerDetails["m_name"]);
+                    });
+
                     if (isset($participatingSloth)) {
                         $participation->sloth = $participatingSloth;
                     } else {
@@ -336,7 +340,11 @@ class ReplayParsing
                     }
                 } elseif ($playerDetails["m_teamId"] == 1) {
                     $participation->team_id = $this->match->teams[$secondReplayTeam]->id;
-                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->first();
+                    // Retrieve all the sloths with matching Heroes Profile ID and then filter on battletag name.
+                    $participatingSloth = Sloth::where('heroesprofile_id', $playerDetails["m_toon"]["m_id"])->get()->first(function ($sloth) use ($playerDetails) {
+                        return strtolower(explode('#', $sloth->battle_tag)[0]) == strtolower($playerDetails["m_name"]);
+                    });
+
                     if (isset($participatingSloth)) {
                         $participation->sloth = $participatingSloth;
                     } else {


### PR DESCRIPTION
Fixes #156 As the Heroes Profile ID (blizz_id) is only guaranteed unique per region I added an additional check on the name portion of the battletag. 

The odds of two accounts with the same Heroes Profile ID having the exact same battletag name is negligible in my opinion and this should give us proper matching.