### PR TITLE
Fix discord_id checks

### DIFF
--- a/plugins/rikki/heroeslounge/components/slothaccount/update.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/update.htm
@@ -228,7 +228,7 @@
                     <div class="input-group-btn">
                         <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
                                 data-request="{{ __SELF__ }}::onSyncDiscord"
-                                title="Sync Discord tag" class="close sync-btn" type="button">
+                                title="Fetch new Discord tag from Discord" class="close sync-btn" type="button">
                             <i class="sync-icon fa fa-refresh" style="color: black;" aria-hidden="true"></i>
                         </button>
                     </div>

--- a/plugins/rikki/heroeslounge/components/slothaccount/update.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/update.htm
@@ -225,16 +225,16 @@
                     </div>
                     {% if __SELF__.sloth.discord_id %}
                     <input class="form-control" placeholder="DiscordTag" title="Discord Tag" type="text" name="discord_tag" disabled value="{{ __SELF__.sloth.discord_tag }}">
+                    <div class="input-group-btn">
+                        <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
+                                data-request="{{ __SELF__ }}::onSyncDiscord"
+                                title="Sync Discord tag" class="close sync-btn" type="button">
+                            <i class="sync-icon fa fa-refresh" style="color: black;" aria-hidden="true"></i>
+                        </button>
+                    </div>
                     {% else %}
                     <input class="form-control" placeholder="DiscordTag" title="Discord Tag" type="text" name="discord_tag" value="{{ __SELF__.sloth.discord_tag }}">
-                    {% endif %}                    
-                    <div class="input-group-btn">
-                            <button style="padding:7px; border:solid #868e96 1px; border-left:none;"
-                                    data-request="{{ __SELF__ }}::onSyncDiscord"
-                                    title="Update Discord tag" class="close sync-btn" type="button">
-                                <i class="sync-icon fa fa-refresh" style="color: black;" aria-hidden="true"></i>
-                            </button>
-                        </div>
+                    {% endif %}
                 </div>
 
                 <div class="input-group col-lg-3 mb-3 col-md-4">

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -231,11 +231,13 @@ class Sloth extends Model
         if ($this->isDirty('team_id')) {
             MailChimpAPI::patchExistingUser($this->user);
         }
-        if ($this->isDirty('discord_tag') && !isset($this->discord_id)) {
+        
+        if ($this->isDirty('discord_tag')) {
             $this->discord_id = Discord\Attendance::GetDiscordUserId($this->discord_tag);
             $this->save();
         }
-        if ($this->isDirty('region_id') && isset($this->discord_id)) {
+
+        if ($this->isDirty('region_id') && !empty($this->discord_id)) {
             if ($this->region_id == 1) {
                 Discord\RoleManagement::UpdateUserRole("DELETE", $this->discord_id, "NA");
                 Discord\RoleManagement::UpdateUserRole("PUT", $this->discord_id, "EU");
@@ -243,7 +245,6 @@ class Sloth extends Model
                 Discord\RoleManagement::UpdateUserRole("DELETE", $this->discord_id, "EU");
                 Discord\RoleManagement::UpdateUserRole("PUT", $this->discord_id, "NA");
             }
-            
         }
     }
 


### PR DESCRIPTION
Cleaned up the `discord_id` checks to actually work as intended.

When a `discord_tag` gets updated, we should always fetch the new `discord_id` (This was already happening, because `!isset($this->discord_id)` always returns true)

We now also no longer needlessly make failed calls for updating region roles for users that we don't have a `discord_id` for. I debated adding code to get the `discord_id` if that is the case, but since we already try to sync up users every week I left it out. 