### PR TITLE
Handle free agent assignment and removal

### DIFF
--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -279,26 +279,27 @@ class SlothAccount extends UserAccount
 
     public function onParticipationSave()
     {
-        try {
-            foreach ($this->seasons as $season) {
-                if ($season->current_round == 0) {
-                    $val = post('part_seas_'.$season->id);
-                    if (isset($val) && !$season->free_agents->contains($this->sloth->id)) {
-                        $season->free_agents()->attach($this->sloth->id);
-                        Discord\RoleManagement::UpdateUserRole("PUT", $this->sloth->discord_id, "FreeAgent");
-                        Flash::success('You will participate in '.$season->title.'!');
-                    } elseif (isset($val) == false) {
-                        $season->free_agents()->detach($this->sloth->id);
-                        Discord\RoleManagement::UpdateUserRole("DELETE", $this->sloth->discord_id, "FreeAgent");
-                        Flash::error('You will not paricipate in '.$season->title.' - Sad to see you go!');
-                    }
+        foreach ($this->seasons as $season) {
+            if ($season->reg_open == 1) {
+                if ($this->sloth->isInTeamParticipatingInSeason($season)) {
+                    Flash::error('You can not update your '.$season->title.' participation, because you are already participating with a team!');
+                    return Redirect::refresh(); 
+                }
+
+                $participation = post('part_seas_'.$season->id);
+                if (isset($participation) && !$season->free_agents->contains($this->sloth->id)) {
+                    $season->free_agents()->attach($this->sloth->id);
+                    Discord\RoleManagement::UpdateUserRole("PUT", $this->sloth->discord_id, "FreeAgent");
+                    Flash::success('You will participate in '.$season->title.'!');
+                } elseif (isset($participation) == false) {
+                    $season->free_agents()->detach($this->sloth->id);
+                    Discord\RoleManagement::UpdateUserRole("DELETE", $this->sloth->discord_id, "FreeAgent");
+                    Flash::error('You will not participate in '.$season->title.' - Sad to see you go!');
                 }
             }
-        } catch (Exception $e) {
-            Flash::error($e->getMessage());
-        } finally {
-            return Redirect::refresh();
         }
+
+        return Redirect::refresh();
     }
 
     public function onUpdateGeneral()
@@ -518,9 +519,8 @@ class SlothAccount extends UserAccount
         if ($sloth->region_id == 2 && isset($data['server_preference'])) {
             $sloth->server_preference = $data['server_preference'];
         }
-        if ($sloth->team_id == 0) {
-            $this->onParticipationSave();
-        }
+
+        $this->onParticipationSave();
         $sloth->save();
 
         Flash::success('Role updated successfully!');

--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -277,31 +277,6 @@ class SlothAccount extends UserAccount
         }
     }
 
-    public function onParticipationSave()
-    {
-        foreach ($this->seasons as $season) {
-            if ($season->reg_open == 1) {
-                if ($this->sloth->isInTeamParticipatingInSeason($season)) {
-                    Flash::error('You can not update your '.$season->title.' participation, because you are already participating with a team!');
-                    return Redirect::refresh(); 
-                }
-
-                $participation = post('part_seas_'.$season->id);
-                if (isset($participation) && !$season->free_agents->contains($this->sloth->id)) {
-                    $season->free_agents()->attach($this->sloth->id);
-                    Discord\RoleManagement::UpdateUserRole("PUT", $this->sloth->discord_id, "FreeAgent");
-                    Flash::success('You will participate in '.$season->title.'!');
-                } elseif (isset($participation) == false) {
-                    $season->free_agents()->detach($this->sloth->id);
-                    Discord\RoleManagement::UpdateUserRole("DELETE", $this->sloth->discord_id, "FreeAgent");
-                    Flash::error('You will not participate in '.$season->title.' - Sad to see you go!');
-                }
-            }
-        }
-
-        return Redirect::refresh();
-    }
-
     public function onUpdateGeneral()
     {
         if (!$user = $this->user()) {
@@ -520,7 +495,6 @@ class SlothAccount extends UserAccount
             $sloth->server_preference = $data['server_preference'];
         }
 
-        $this->onParticipationSave();
         $sloth->save();
 
         Flash::success('Role updated successfully!');

--- a/plugins/rikki/heroeslounge/components/ViewApps.php
+++ b/plugins/rikki/heroeslounge/components/ViewApps.php
@@ -123,9 +123,9 @@ class ViewApps extends ComponentBase
 
                         $seasons = Season::all();
                         foreach ($seasons as $season) {
-                            if ($season->reg_open == 1 && $season->teams->contains($team) && $season->free_agents->contains($this->sloth)) {
-                                $season->free_agents()->detach($this->sloth->id);
-                                Discord\RoleManagement::UpdateUserRole("DELETE", $sloth->discord_id, "FreeAgent");
+                            if ($season->reg_open && $season->teams->contains($team) && $season->free_agents->contains($this->sloth)) {
+                                $season->free_agents()->remove($this->sloth);
+                                Discord\RoleManagement::UpdateUserRole("DELETE", $this->sloth->discord_id, "FreeAgent");
                             }
                         }
                         

--- a/plugins/rikki/heroeslounge/components/ViewApps.php
+++ b/plugins/rikki/heroeslounge/components/ViewApps.php
@@ -15,12 +15,14 @@ use Cms\Classes\ComponentBase;
 use RainLab\User\Models\Settings as UserSettings;
 use Exception;
 use October\Rain\Support\Collection;
+use Rikki\Heroeslounge\classes\Discord;
 
 use RainLab\User\Components\Account as UserAccount;
 use Rikki\Heroeslounge\Models\Sloth as SlothModel;
 use Rikki\Heroeslounge\Models\Team as Teams;
 use Rikki\Heroeslounge\Models\Apps as Applications;
 use Rikki\Heroeslounge\Models\Timeline;
+use Rikki\Heroeslounge\Models\Season;
 
 class ViewApps extends ComponentBase
 {
@@ -118,6 +120,15 @@ class ViewApps extends ComponentBase
                     //a sloth should not participate in two different teams in the same season or tournament
                     if ($this->sloth->mayJoinTeam($team)) {
                         $this->sloth->teams()->add($team);
+
+                        $seasons = Season::all();
+                        foreach ($seasons as $season) {
+                            if ($season->reg_open == 1 && $season->teams->contains($team) && $season->free_agents->contains($this->sloth)) {
+                                $season->free_agents()->detach($this->sloth->id);
+                                Discord\RoleManagement::UpdateUserRole("DELETE", $sloth->discord_id, "FreeAgent");
+                            }
+                        }
+                        
                         $this->sloth->save();
 
                         $app->accepted = 1;

--- a/plugins/rikki/heroeslounge/components/slothaccount/update.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/update.htm
@@ -284,33 +284,6 @@
             </select>
         </div>
         {% endif %}
-
-        <!-- START PARTICIPATION -->
-
-        <hr class="separator">
-
-        <h3>Participation</h3>
-        <p>
-            Season participation as a free agent.
-        </p>
-        {% set checked = '0' %}
-        {% for season in __SELF__.seasons %}
-            {% for sloth in season.free_agents %}
-                {% if sloth.id == __SELF__.sloth.id %}
-                    {% set checked = '1' %}
-                {% endif %}
-            {% endfor %}
-            <div>
-                <label>
-                    <input type="checkbox" name="part_seas_{{season.id}}" {% if checked %} checked {% endif %} disabled>
-                    {{season.title}}
-                </label>
-            </div>
-            {% set checked = '0' %}
-        {% endfor %}
-
-        <!-- END PARTICIPATION -->
-
         <br>
         <button type="submit" class="btn btn-primary mt-2">Save</button>
         {{ form_close() }}

--- a/plugins/rikki/heroeslounge/components/slothaccount/update.htm
+++ b/plugins/rikki/heroeslounge/components/slothaccount/update.htm
@@ -271,7 +271,6 @@
                 {%  for role in __SELF__.roles %}
                 <option value="{{role.id}}" {% if __SELF__.sloth.role_id == role.id %} selected {% endif %}>{{role.title}}</option>
                 {% endfor %}
-
             </select>
         </div>
 
@@ -286,29 +285,35 @@
         </div>
         {% endif %}
 
-        {% if __SELF__.sloth.team_id == 0 %}
         <!-- START PARTICIPATION -->
 
         <hr class="separator">
 
         <h3>Participation</h3>
-        {% set checked = '0' %} {% for season in __SELF__.seasons %} {% for sloth in season.free_agents %} {% if sloth.id == __SELF__.sloth.id
-        %} {% set checked = '1' %} {% endif %} {% endfor %}
-        <div class="form-check{% if season.reg_open == 0 %} disabled has-danger{% endif %}">
-            <label class="form-check-label">
-                <input type="checkbox" class="form-check-input" {% if season.reg_open == 0 %}disabled{% endif %} name="part_seas_{{season.id}}"  {% if checked == '1' %}checked{% endif %} >
-                {{season.title}}
-                </label> {% if season.reg_open == 0 %}
-            <small class="form-control-feedback">
-                Registration for season is closed!
-            </small> {% endif %}
-        </div>
-        {% set checked = '0' %} {% endfor %}
+        <p>
+            Season participation as a free agent.
+        </p>
+        {% set checked = '0' %}
+        {% for season in __SELF__.seasons %}
+            {% for sloth in season.free_agents %}
+                {% if sloth.id == __SELF__.sloth.id %}
+                    {% set checked = '1' %}
+                {% endif %}
+            {% endfor %}
+            <div>
+                <label>
+                    <input type="checkbox" name="part_seas_{{season.id}}" {% if checked %} checked {% endif %} disabled>
+                    {{season.title}}
+                </label>
+            </div>
+            {% set checked = '0' %}
+        {% endfor %}
 
         <!-- END PARTICIPATION -->
-        {% endif %}
+
         <br>
-        <button type="submit" class="btn btn-primary mt-2">Save</button>        {{ form_close() }}
+        <button type="submit" class="btn btn-primary mt-2">Save</button>
+        {{ form_close() }}
     </div>
     <!-- END GAME TAB-->
 

--- a/plugins/rikki/loungeviews/components/ParticipationOverview.php
+++ b/plugins/rikki/loungeviews/components/ParticipationOverview.php
@@ -118,12 +118,10 @@ class ParticipationOverview extends ComponentBase
         $this->season = Seasons::find($_POST['season_id']);
         if ($this->user != null) {
             $sloth = $this->user->sloth;
-            if ($sloth != null && $sloth->region_id == $this->season->region_id && $this->season->free_agents->contains($sloth)) {
-                $this->season->free_agents()->remove($sloth);
-                Discord\RoleManagement::UpdateUserRole("DELETE", $sloth->discord_id, "FreeAgent");
-                Flash::error('You will not participate in '. $this->season->title. ' - Sad to see you go!');
-                return Redirect::refresh();
-            }
+            $this->season->free_agents()->remove($sloth);
+            Discord\RoleManagement::UpdateUserRole("DELETE", $sloth->discord_id, "FreeAgent");
+            Flash::error('You will not participate in '. $this->season->title. ' - Sad to see you go!');
+            return Redirect::refresh();
         }
     }
 }

--- a/plugins/rikki/loungeviews/components/ParticipationOverview.php
+++ b/plugins/rikki/loungeviews/components/ParticipationOverview.php
@@ -5,6 +5,7 @@ use Cms\Classes\ComponentBase;
 use Auth;
 use Rikki\Heroeslounge\Models\Season as Seasons;
 use Rikki\Heroeslounge\Models\Team;
+use Rikki\Heroeslounge\classes\Discord;
 use Log;
 use Redirect;
 use Flash;
@@ -80,13 +81,20 @@ class ParticipationOverview extends ComponentBase
                 if ($eligible === true) {
                     $this->season->teams()->add($team);
                     Flash::success('Your team is now signed up for '.$this->season->title);
+
+                    foreach ($team->sloths as $sloth) {
+                        if ($this->season->free_agents->contains($sloth->id)) {
+                            $this->season->free_agents()->detach($sloth->id);
+                            Discord\RoleManagement::UpdateUserRole("DELETE", $sloth->discord_id, "FreeAgent");
+                        }
+                    }
+
                     return Redirect::refresh();
                 } else {
                     //$eligible holds a sloth that is already participating with another team
                     Flash::error('A member of this team is already participating with another team: '.$eligible->title);
                     return Redirect::refresh();
                 }
-                
             }
         }
     }

--- a/plugins/rikki/loungeviews/components/participationoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/participationoverview/default.htm
@@ -34,7 +34,9 @@
         </button>
         <br><br>
     </div>
-    {% elseif __SELF__.user and __SELF__.user.sloth in __SELF__.season.free_agents %}
+    {% endif %}
+
+    {% for agent in __SELF__.season.free_agents if __SELF__.user and agent.id == __SELF__.user.sloth.id %}
     <div>
         You are signed up as a free agent.<br>
         No longer want to particpate as a free agent?<br>
@@ -45,7 +47,8 @@
             Remove free agent sign up
         </button>
     </div>
-    {% endif %}
+    {% endfor %}
+
 </div>
 <nav class="navbar navbar-expand-lg navbar-light">
     <div class="navbar-header">

--- a/plugins/rikki/loungeviews/components/participationoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/participationoverview/default.htm
@@ -34,8 +34,9 @@
         </button>
         <br><br>
     </div>
-    {% elseif __SELF__.user and __SELF__.signedUp and __SELF__.user.sloth.region_id == __SELF__.season.region_id %}
+    {% elseif __SELF__.user and __SELF__.signedUp and __SELF__.user.sloth in __SELF__.season.free_agents %}
     <div>
+        You are signed up as a free agent.<br>
         No longer want to particpate as a free agent?<br>
         <button type="button" 
                 class="btn btn-sm btn-secondary center"

--- a/plugins/rikki/loungeviews/components/participationoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/participationoverview/default.htm
@@ -34,7 +34,7 @@
         </button>
         <br><br>
     </div>
-    {% elseif __SELF__.user and __SELF__.signedUp and __SELF__.user.sloth in __SELF__.season.free_agents %}
+    {% elseif __SELF__.user and __SELF__.user.sloth in __SELF__.season.free_agents %}
     <div>
         You are signed up as a free agent.<br>
         No longer want to particpate as a free agent?<br>

--- a/plugins/rikki/loungeviews/components/participationoverview/default.htm
+++ b/plugins/rikki/loungeviews/components/participationoverview/default.htm
@@ -30,9 +30,19 @@
                 class="btn btn-sm btn-secondary center"
                 data-request-data="season_id: {{__SELF__.season.id}}"
                 data-request="{{ __SELF__ }}::onSlothSignup">
-            Sign up as a free agent!
+            Sign up as a free agent
         </button>
         <br><br>
+    </div>
+    {% elseif __SELF__.user and __SELF__.signedUp and __SELF__.user.sloth.region_id == __SELF__.season.region_id %}
+    <div>
+        No longer want to particpate as a free agent?<br>
+        <button type="button" 
+                class="btn btn-sm btn-secondary center"
+                data-request-data="season_id: {{__SELF__.season.id}}"
+                data-request="{{ __SELF__ }}::onSlothRemoveSignUp">
+            Remove free agent sign up
+        </button>
     </div>
     {% endif %}
 </div>


### PR DESCRIPTION
Fixes #126 and #140.

Users will be removed from the Free Agent list if they join a team signed up to a season with open registration or one of their teams signs up for a season.

Also allows users signed up as a Free Agent, but not participating with a team to remove their sign up from a season with open registration.