### PR TITLE
Add map losses and map score to division table

### DIFF
--- a/plugins/rikki/loungeviews/components/DivisionTable.php
+++ b/plugins/rikki/loungeviews/components/DivisionTable.php
@@ -42,17 +42,24 @@ class DivisionTable extends ComponentBase
                 //calculate game wins
                 foreach ($this->teams as $team) {
                     $team->game_wins = 0;
+                    $team->game_losses = 0;
                 }
                 foreach ($div->matches as $match) {
-                    foreach ($match->games as $game) {
-                        $team = $this->teams->where('id', $game->winner_id)->first();
-                        if ($game->winner_id != 0 && $game->winner_id != null && $team != null) {
-                            $this->teams->where('id', $game->winner_id)->first()->game_wins++;
-                        }
+                    $teamOne = $this->teams->where('id', $match->teams[0]->id)->first();
+                    $teamTwo = $this->teams->where('id', $match->teams[1]->id)->first();
+
+                    if ($teamOne) {
+                        $this->teams->where('id', $teamOne->id)->first()->game_wins += $match->teams[0]->pivot->team_score;
+                        $this->teams->where('id', $teamOne->id)->first()->game_losses += $match->teams[1]->pivot->team_score;
                     }
+
+                    if ($teamTwo) {
+                        $this->teams->where('id', $teamTwo->id)->first()->game_wins += $match->teams[1]->pivot->team_score;
+                        $this->teams->where('id', $teamTwo->id)->first()->game_losses += $match->teams[0]->pivot->team_score;
+                    }                    
                 }
                 $this->teams = $this->teams->sortByDesc(function ($team) {
-                    return 1000000*$team->pivot->win_count + 1000*$team->game_wins + $team->pivot->match_count - 0.001 * $team->pivot->free_win_count - 0.001 * $team->pivot->bye;
+                    return 1000000*$team->pivot->win_count + 1000*$team->game_wins - 0.01*$team->game_losses - 0.001 * $team->pivot->free_win_count - 0.001 * $team->pivot->bye;
                 });
             }
 

--- a/plugins/rikki/loungeviews/components/divisiontable/default.htm
+++ b/plugins/rikki/loungeviews/components/divisiontable/default.htm
@@ -10,6 +10,9 @@
             <th>
                 Team
             </th>
+            <th>
+                Matches
+            </th>
             {% if __SELF__.showScore %}
             <th>
                 Score
@@ -19,16 +22,18 @@
             </th>
             {% else %}
             <th>
+                Wins
+            </th>
+            <th>
                 Map Wins
             </th>
             <th>
-                Wins
+                Map Losses
+            </th>
+            <th>
+                Map Score
             </th>
             {% endif %}
-            <th>
-                Matches
-            </th>
-            
         </tr>
     </thead>
     <tbody>
@@ -43,14 +48,16 @@
                 {% endif %}
             </td>
             <td><a href="{{ 'team/view'|page({ slug: team.slug }) }}" style="color:#34495e;text-decoration:underline">{{team.title}}</a></td>
+            <td>{{team.pivot.match_count}}</td>
             {% if __SELF__.showScore %}
             <td class="score notext">{{team.score}}</td>
             <td class="score notext">{{team.map_score}}</td>
             {% else %}
-            <td class="score notext">{{team.game_wins}}</td>
             <td class="score notext">{{team.pivot.win_count}}</td>
+            <td class="score notext">{{team.game_wins}}</td>
+            <td class="score notext">{{team.game_losses}}</td>
+            <td class="score notext">{{team.game_wins - team.game_losses}}</td>
             {% endif %}
-            <td>{{team.pivot.match_count}}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/plugins/rikki/loungeviews/components/divisiontable/default.htm
+++ b/plugins/rikki/loungeviews/components/divisiontable/default.htm
@@ -28,9 +28,6 @@
                 Map Wins
             </th>
             <th>
-                Map Losses
-            </th>
-            <th>
                 Map Score
             </th>
             {% endif %}
@@ -55,7 +52,6 @@
             {% else %}
             <td class="score notext">{{team.pivot.win_count}}</td>
             <td class="score notext">{{team.game_wins}}</td>
-            <td class="score notext">{{team.game_losses}}</td>
             <td class="score notext">{{team.game_wins - team.game_losses}}</td>
             {% endif %}
         </tr>


### PR DESCRIPTION
Fixes #120 I think? I did not account for head to head results in the sorting, but this should be an improvement nonetheless. I also reordered the division table to look like tables in other sports and added map scores. I can remove the map scores if they're too much clutter. 

I tried playing around with`match_count` as sort weight, but I didn't find one that worked, so I removed it. 

Example of new table from [Season 8 division 4](https://heroeslounge.gg/eu-season-8/division-4):

![image](https://user-images.githubusercontent.com/6303961/68172980-c0115d80-ff79-11e9-9720-53b46661eb4d.png)
