### PR TITLE
Rework registration and updating sloths

### DIFF
--- a/plugins/rikki/heroeslounge/classes/hotslogs/IDFetcher.php
+++ b/plugins/rikki/heroeslounge/classes/hotslogs/IDFetcher.php
@@ -83,7 +83,6 @@ class IDFetcher
                 }
             }
         }
-        $sloth->save();
 
         // Check if we've hit the rate-limit and retry the request.
         if (array_key_exists('retry-after', $headers)) {

--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -221,11 +221,6 @@ class SlothAccount extends UserAccount
                 Auth::login($user);
             }
 
-
-            /*
-            * Attach a Sloth to the user
-            */
-
             $sloth = new SlothModel;
             $sloth->user = $user;
             $sloth->title = $user->username;

--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -26,8 +26,6 @@ use Rikki\Heroeslounge\Models\SlothRole;
 use Rikki\Heroeslounge\Models\Timeline;
 use Rikki\Heroeslounge\classes\Mailchimp\MailChimpAPI;
 use Rikki\Heroeslounge\Models\Region as Region;
-use Rikki\Heroeslounge\classes\hotslogs\IDFetcher;
-use Rikki\Heroeslounge\classes\mmr\MMRFetcher;
 
 class SlothAccount extends UserAccount
 {
@@ -236,9 +234,6 @@ class SlothAccount extends UserAccount
 
             $sloth->save();
             $this->user = $user;
-
-            IDFetcher::fetchIDHeroesProfile($sloth);
-            MMRFetcher::updateMMRHeroesProfile($sloth);
 
             /*
               Assign EU or NA role on Discord based on region_id.

--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -223,35 +223,25 @@ class SlothAccount extends UserAccount
 
 
             /*
-            * Make sure the user gets a Sloth attached
+            * Attach a Sloth to the user
             */
 
-            $sloth = SlothModel::getFromUser($user);
+            $sloth = new SlothModel;
+            $sloth->user = $user;
+            $sloth->title = $user->username;
             $sloth->battle_tag = $data['battle_tag'];
             $sloth->discord_tag = $strippedDiscordTag;
             $sloth->discord_id = $userDiscordId;
             $sloth->region_id = $data['region_id'];
-
             $sloth->save();
-            $this->user = $user;
 
-            /*
-              Assign EU or NA role on Discord based on region_id.
-              region_id = 1: EU
-              region_id = 2: NA
-            */
-
-            if ($sloth->region_id == 1) {
-              Discord\RoleManagement::UpdateUserRole("PUT", $sloth->discord_id, "EU");
-            } else if ($sloth->region_id == 2) {
-              Discord\RoleManagement::UpdateUserRole("PUT", $sloth->discord_id, "NA");
-            }
+            $this->user = $sloth->user;
 
             // sign up for newsletter
             if (array_key_exists('newsletter_subscription', $data) && $data['newsletter_subscription']) {
-                MailChimpAPI::subscribeNewUser($user);
+                MailChimpAPI::subscribeNewUser($sloth->user);
             } else {
-                MailChimpAPI::unsubscribeNewUser($user);
+                MailChimpAPI::unsubscribeNewUser($sloth->user);
             }
 
             /*

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -247,6 +247,11 @@ class Sloth extends Model
                 Discord\RoleManagement::UpdateUserRole("PUT", $this->discord_id, "NA");
             }
         }
+
+        if ($this->isDirty('battle_tag') || $this->heroesprofile_id == null) {
+            IDFetcher::fetchIDHeroesProfile($this);
+            MMRFetcher::updateMMRHeroesProfile($this);
+        }
     }
 
     public function beforeDelete()

--- a/plugins/rikki/heroeslounge/models/Sloth.php
+++ b/plugins/rikki/heroeslounge/models/Sloth.php
@@ -145,9 +145,6 @@ class Sloth extends Model
         MMRFetcher::updateMMRHeroesProfile($this);
 
         $this->_saveTimelineEntry('Sloth.Created');
-        if (!empty($this->team_id)) {
-            $this->_saveTimelineEntry('Sloth.Joins.Team');
-        }
     }
 
     public function beforeUpdate()
@@ -172,11 +169,6 @@ class Sloth extends Model
         if ($this->isDirty('battle_tag') || $this->heroesprofile_id == null) {
             IDFetcher::fetchIDHeroesProfile($this);
         }
-    }
-
-    public function beforeDelete()
-    {
-        $this->_saveTimelineEntry('Sloth.Deleted');
     }
 
     public function leaveTeam($team)


### PR DESCRIPTION
I noticed that there's currently no way to get a new `heroesprofile_id` when a user changes their battletag or a way for moderators to force a resync if a user does happen to get out of sync.

This fix fetches Heroes Profile data for newly registering users or users that get their battletag changed (Also triggers if the sloth's `heroesprofile_id` is null and a different field is updated).

I tested all of this locally and it worked as expected for new registrations and user updates.