### PR TITLE
Fix and enhance match reschedule notification logic

### DIFF
--- a/plugins/rikki/heroeslounge/classes/discord/Webhook.php
+++ b/plugins/rikki/heroeslounge/classes/discord/Webhook.php
@@ -5,7 +5,7 @@ use Log;
 
 class Webhook
 {
-    public static function sendMatchReschedule($message)
+    public static function sendMatchReschedule($message = "", $embed)
     {
         $url = 'https://discordapp.com/api/webhooks/' . Authcode::getCasterWebhookId() . '/' . Authcode::getCasterWebhookSecret();
 
@@ -14,7 +14,7 @@ class Webhook
             "User-Agent: HeroesLounge (http://heroeslounge.gg, 0.1)"
         ];
 
-        $payload = json_encode(['content' => $message]);
+        $payload = json_encode(['content' => $message, 'embeds' => [$embed]]);
 
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);

--- a/plugins/rikki/heroeslounge/components/UpdateMatch.php
+++ b/plugins/rikki/heroeslounge/components/UpdateMatch.php
@@ -8,7 +8,6 @@ use Rikki\Heroeslounge\Models\Map;
 use Rikki\Heroeslounge\Models\Team;
 use Rikki\Heroeslounge\Models\Match;
 use Rikki\Heroeslounge\classes\ReplayParsing\ReplayParsing;
-use Rikki\Heroeslounge\classes\Discord\Webhook;
 use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 use DateTime;
 use DateTimeZone;
@@ -92,29 +91,6 @@ class UpdateMatch extends ComponentBase
                 $match->wbp = $wbp->format('Y-m-d H:i:s');
                 if ($match->tbp != null && Carbon::parse($match->wbp) < Carbon::parse($match->tbp)) {
                     $match->save();
-
-                    if ($match->casters->count() > 0) {
-                        $newDate = new DateTime($match->wbp, new DateTimeZone(TimezoneHelper::defaultTimezone()));
-                        $oldDate = new DateTime($oldWBP, new DateTimeZone(TimezoneHelper::defaultTimezone()));
-                        if ($match->teams[0]->region_id == 1) {
-                            $newDate->setTimezone(new DateTimeZone('Europe/Berlin'));
-                            $oldDate->setTimezone(new DateTimeZone('Europe/Berlin'));
-                        } else if ($match->teams[0]->region_id == 2) {
-                            $newDate->setTimezone(new DateTimeZone('America/Los_Angeles'));
-                            $oldDate->setTimezone(new DateTimeZone('America/Los_Angeles'));
-                        }
-        
-                        // Create our information message to inform assigned / pending casters.
-                        $notificationString = "The match between " . $match->teams[0]->title . " and " . $match->teams[1]->title . " has been rescheduled from " . $oldDate->format('d M Y H:i T') . " to " . $newDate->format('d M Y H:i T') . "\n";
-                        foreach ($match->casters as $caster) {
-                            if ($caster->pivot->approved != 2) {
-                                $notificationString .= "<@" . $caster->discord_id . ">\n";
-                            }
-                        }
-                        
-                        Webhook::sendMatchReschedule($notificationString);
-                    }
-                    
                     Flash::success('Match has been successfully rescheduled for '.$date);
                 } else {
                     $tbp = new DateTime($match->tbp, new DateTimeZone(TimezoneHelper::defaultTimezone()));


### PR DESCRIPTION
This moves the match reschedule logic to the model event so that it can trigger consistently on match reschedules. E.g: In the case that someone was to reschedule a match from the back-end.

Also fixes a bug that a notifications would still appear when all casters are denied.
When we're missing `discord_id` data from a caster, we'll reference their website username instead of an empty mention.
