### PR TITLE
Improves performance for team hero and map stats

### DIFF
--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -2,7 +2,6 @@
 
 use Rikki\Heroeslounge\Models\Hero;
 use Rikki\Heroeslounge\Models\Map;
-use Rikki\Heroeslounge\Models\Team;
 use October\Rain\Support\Collection;
 
 class Statistics

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -130,8 +130,6 @@ class Statistics
 
     public static function calculateHeroStatisticsForTeam($team, $season)
     {
-        $team = Team::WithMatches()->where('id', $team->id)->first();
-
         $allHeroes = Hero::all()->sortBy('title');
         $heroesArray = [];
         foreach ($allHeroes as $hero) {
@@ -233,9 +231,7 @@ class Statistics
     }
 
     public static function calculateMapStatisticsForTeam($team, $season)
-    {
-        $team = Team::with('matches')->with('matches.games')->with('matches.games.map')->with('matches.games.replay')->with('matches.games.gameParticipations')->where('id', $team->id)->first();
-        
+    {        
         $games = [];
         $teams = [];
         $i = 0;

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -2,6 +2,7 @@
 
 use Rikki\Heroeslounge\Models\Hero;
 use Rikki\Heroeslounge\Models\Map;
+use Rikki\Heroeslounge\Models\Team;
 use October\Rain\Support\Collection;
 
 class Statistics
@@ -129,6 +130,8 @@ class Statistics
 
     public static function calculateHeroStatisticsForTeam($team, $season)
     {
+        $team = Team::WithMatches()->where('id', $team->id)->first();
+
         $allHeroes = Hero::all()->sortBy('title');
         $heroesArray = [];
         foreach ($allHeroes as $hero) {
@@ -231,6 +234,8 @@ class Statistics
 
     public static function calculateMapStatisticsForTeam($team, $season)
     {
+        $team = Team::with('matches')->with('matches.games')->with('matches.games.map')->with('matches.games.replay')->with('matches.games.gameParticipations')->where('id', $team->id)->first();
+        
         $games = [];
         $teams = [];
         $i = 0;

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -231,7 +231,7 @@ class Statistics
     }
 
     public static function calculateMapStatisticsForTeam($team, $season)
-    {        
+    {
         $games = [];
         $teams = [];
         $i = 0;

--- a/plugins/rikki/loungestatistics/http/Team.php
+++ b/plugins/rikki/loungestatistics/http/Team.php
@@ -15,27 +15,27 @@ class Team extends Controller
 
     public function herostatistics($id)
     {
-        $team = TeamModel::findOrFail($id);
+        $team = TeamModel::WithMatches()->where('id', $id)->firstOrFail();
         return Statistics::calculateHeroStatisticsForTeam($team, null);
     }
 
     public function seasonHerostatistics($id, $seasonId)
     {
         $season = Season::findOrFail($seasonId);
-        $team = TeamModel::findOrFail($id);
+        $team = TeamModel::WithMatches()->where('id', $id)->firstOrFail();
         return Statistics::calculateHeroStatisticsForTeam($team, $season);
     }
 
     public function mapstatistics($id)
     {
-        $team = TeamModel::findOrFail($id);
+        $team = TeamModel::with('matches', 'matches.games', 'matches.games.map', 'matches.games.replay', 'matches.games.gameParticipations')->where('id', $id)->firstOrFail();
         return Statistics::calculateMapStatisticsForTeam($team, null);
     }
 
     public function seasonMapstatistics($id, $seasonId)
     {
         $season = Season::findOrFail($seasonId);
-        $team = TeamModel::findOrFail($id);
+        $team = TeamModel::with('matches', 'matches.games', 'matches.games.map', 'matches.games.replay', 'matches.games.gameParticipations')->where('id', $id)->firstOrFail();
         return Statistics::calculateMapStatisticsForTeam($team, $season);
     }
 }


### PR DESCRIPTION
Optimized the database query to fetch all the data in one go, instead of fetching individual pieces during the later loops. 

Observed about a 100x performance increase locally for api endpoints for both. The front-end didn't have this issue. 

I didn't observer a noticeable increase for sloth statistics, so I didn't change those.