### PR TITLE
Improve performance of sloth and team stats for frontend

### DIFF
--- a/plugins/rikki/heroeslounge/models/Game.php
+++ b/plugins/rikki/heroeslounge/models/Game.php
@@ -149,16 +149,16 @@ class Game extends Model
         return $this->gameParticipations->where('team_id', $this->team_two_id)->sortBy('draft_order');
     }
 
-    public function getFirstPickTeam()
+    public function getFirstPickTeamId()
     {
         $participation = $this->gameParticipations->where('draft_order', 1)->first();
-        return ($participation ? ($participation->team ? $participation->team->title : '') : '');
+        return ($participation && $participation->team_id ? $participation->team_id : '');
     }
 
-    public function getSecondPickTeam()
+    public function getSecondPickTeamId()
     {
         $participation = $this->gameParticipations->where('draft_order', 2)->first();
-        return ($participation ? ($participation->team ? $participation->team->title : '') : '');
+        return ($participation && $participation->team_id ? $participation->team_id : '');
     }
 
     public function getTeamsGrouped()

--- a/plugins/rikki/heroeslounge/models/GameParticipation.php
+++ b/plugins/rikki/heroeslounge/models/GameParticipation.php
@@ -60,8 +60,6 @@ class GameParticipation extends Model
 
     public function isInSecondPickTeam()
     {
-        $secondPickSloths = [2, 3, 6, 7, 10];
-
-        return in_array($this->draft_order, $secondPickSloths);
+        return in_array($this->draft_order, [2, 3, 6, 7, 10]);
     }
 }

--- a/plugins/rikki/heroeslounge/models/GameParticipation.php
+++ b/plugins/rikki/heroeslounge/models/GameParticipation.php
@@ -60,6 +60,6 @@ class GameParticipation extends Model
 
     public function isInSecondPickTeam()
     {
-        return in_array($this->draft_order, [2, 3, 6, 7, 10]);
+        return $this->draft_order == 2 || $this->draft_order == 3 || $this->draft_order == 6 || $this->draft_order == 7 || $this->draft_order == 10;
     }
 }

--- a/plugins/rikki/heroeslounge/models/GameParticipation.php
+++ b/plugins/rikki/heroeslounge/models/GameParticipation.php
@@ -57,4 +57,11 @@ class GameParticipation extends Model
     {
         return $this->talents()->orderBy('talent_tier', 'asc')->get();
     }
+
+    public function isInSecondPickTeam()
+    {
+        $secondPickSloths = [2, 3, 6, 7, 10];
+
+        return in_array($this->draft_order, $secondPickSloths);
+    }
 }

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -254,7 +254,7 @@ class Statistics
     }
 
     // $teamIds has a teamId entry for every game in $games.
-    // $gameParticipations has a participation entry for game in $games when analyzing sloths.
+    // $gameParticipations has a participation entry for every game in $games when analyzing sloths.
     public static function analyzeGamesForMapStats($games, $teamIds, $gameParticipations) {
         $allMaps = Map::all()->sortBy('title');
         $mapArray = [];

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -248,11 +248,9 @@ class Statistics
 
         $mapArray = Self::analyzeGamesForMapStats($games, $teamIds, null);
         $maps2 = new Collection($mapArray);
-        $filteredMaps = $maps2->reject(function ($map_array) {
+        return $maps2->reject(function ($map_array) {
             return $map_array['picks_by'] + $map_array['picks_vs'] == 0;
         });
-
-        return $filteredMaps;
     }
 
     // $teamIds has a teamId entry for every game in $games.

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -56,14 +56,14 @@ class Statistics
     {
         foreach ($gameParticipations as $gP) {
             $game = $gP->game;
-            $team = $gP->team;
-            if ($gP->hero == null || $game == null || $team == null) {
+            $teamId = $gP->team_id;
+            if ($gP->hero == null || $game == null || $teamId == null) {
                 continue;
             }
 
             if ($season == null || ($gP->game != null && $gP->game->match != null && $gP->game->match->belongsToSeason($season))) {
                 // Find out if we are team one in the replay.
-                $isTeamOne = ($game->team_one_id == $team->id);
+                $isTeamOne = ($game->team_one_id == $teamId);
                 
                 $game->getTeamOneBans()->each( function ($item) use ($isTeamOne, &$heroesArray) {
                     if ($isTeamOne) {
@@ -81,7 +81,7 @@ class Statistics
                 });
 
                 $heroesArray[$gP->hero->title]['picks']++;
-                if ($game->winner_id == $team->id) {
+                if ($game->winner_id == $teamId) {
                     $heroesArray[$gP->hero->title]['wins']++;
                 }
 
@@ -215,10 +215,10 @@ class Statistics
         foreach ($gameParticipations as $gP) {
             if ($season == null || ($gP->game != null && $gP->game->match != null && $gP->game->match->belongsToSeason($season))) {
                 $game = $gP->game;
-                $team = $gP->team;
-                if ($game != null and $team != null) {
+                $teamId = $gP->team_id;
+                if ($game != null and $teamId != null) {
                     $games[$i] = $game;
-                    $teams[$i] = $team;
+                    $teams[$i] = $teamId;
                     $i = $i + 1;
                 }
             }
@@ -240,7 +240,7 @@ class Statistics
             if ($season == null or $match->belongsToSeason($season)) {
                 foreach ($match->games as $game) {
                     $games[$i] = $game;
-                    $teams[$i] = $team;
+                    $teams[$i] = $team->id;
                     $i = $i + 1;
                 }
             }
@@ -268,12 +268,12 @@ class Statistics
         }
         foreach ($games as $i=>$game) {
             if ($game->map && $game->replay) {
-                if ($teams[$i]->id == $game->getSecondPickTeamId()) {
+                if ($teams[$i] == $game->getSecondPickTeamId()) {
                     $mapArray[$game->map->title]['picks_by']++;
                 } else {
                     $mapArray[$game->map->title]['picks_vs']++;
                 }
-                if ($game->winner_id == $teams[$i]->id) {
+                if ($game->winner_id == $teams[$i]) {
                     $mapArray[$game->map->title]['winrate']++;
                 }
             }

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -291,9 +291,9 @@ class Statistics
 
     private static function isInSecondPickTeam($i, $games, $teamIds, $gameParticipations) {
         if ($gameParticipations != null) {
-            return $teamIds[$i] == $gameParticipations[$i]->isInSecondPickTeam();
+            return $gameParticipations[$i]->isInSecondPickTeam();
         } else {
-            return $teamIds[$i] == $game->getSecondPickTeamId();
+            return $teamIds[$i] == $games[$i]->getSecondPickTeamId();
         }
     }
 }

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -4,6 +4,8 @@ use Rikki\Heroeslounge\Models\Hero;
 use Rikki\Heroeslounge\Models\Map;
 use October\Rain\Support\Collection;
 
+use Log;
+
 class Statistics
 {
     /*
@@ -266,7 +268,7 @@ class Statistics
         }
         foreach ($games as $i=>$game) {
             if ($game->map && $game->replay) {
-                if ($teams[$i]->title == $game->getSecondPickTeam()) {
+                if ($teams[$i]->id == $game->getSecondPickTeamId()) {
                     $mapArray[$game->map->title]['picks_by']++;
                 } else {
                     $mapArray[$game->map->title]['picks_vs']++;

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -267,18 +267,10 @@ class Statistics
         }
         foreach ($games as $i=>$game) {
             if ($game->map && $game->replay) {
-                if ($gameParticipations != null) {
-                    if ($teamIds[$i] == $gameParticipations[$i]->isInSecondPickTeam()) {
-                        $mapArray[$game->map->title]['picks_by']++;
-                    } else {
-                        $mapArray[$game->map->title]['picks_vs']++;
-                    }
+                if (SELF::isInSecondPickTeam($i, $games, $teamIds, $gameParticipations)) {
+                    $mapArray[$game->map->title]['picks_by']++;
                 } else {
-                    if ($teamIds[$i] == $game->getSecondPickTeamId()) {
-                        $mapArray[$game->map->title]['picks_by']++;
-                    } else {
-                        $mapArray[$game->map->title]['picks_vs']++;
-                    }
+                    $mapArray[$game->map->title]['picks_vs']++;
                 }
                 if ($game->winner_id == $teamIds[$i]) {
                     $mapArray[$game->map->title]['winrate']++;
@@ -295,5 +287,13 @@ class Statistics
             $mapArray[$key] = $map_array;
         }
         return $mapArray;
+    }
+
+    private static function isInSecondPickTeam($i, $games, $teamIds, $gameParticipations) {
+        if ($gameParticipations != null) {
+            return $teamIds[$i] == $gameParticipations[$i]->isInSecondPickTeam();
+        } else {
+            return $teamIds[$i] == $game->getSecondPickTeamId();
+        }
     }
 }

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -4,8 +4,6 @@ use Rikki\Heroeslounge\Models\Hero;
 use Rikki\Heroeslounge\Models\Map;
 use October\Rain\Support\Collection;
 
-use Log;
-
 class Statistics
 {
     /*
@@ -251,7 +249,7 @@ class Statistics
         $filteredMaps = $maps2->reject(function ($map_array) {
             return $map_array['picks_by'] + $map_array['picks_vs'] == 0;
         });
-        
+
         return $filteredMaps;
     }
 

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -208,20 +208,20 @@ class Statistics
     public static function calculateMapStatisticsForSloth($gameParticipations, $season)
     {
         $participations = [];
-        $teams = [];
+        $teamIds = [];
         $i = 0;
         foreach ($gameParticipations as $gP) {
             if ($season == null || ($gP->game != null && $gP->game->match != null && $gP->game->match->belongsToSeason($season))) {
                 $teamId = $gP->team_id;
-                if ($gP->game != null and $teamId != null) {
+                if ($gP->game != null && $teamId != null) {
                     $participations[$i] = $gP;
-                    $teams[$i] = $teamId;
+                    $teamIds[$i] = $teamId;
                     $i = $i + 1;
                 }
             }
         }
 
-        $mapArray = Self::analyzeGamesForMapStatsSloth($participations, $teams);
+        $mapArray = Self::analyzeGamesForMapStatsSloth($participations, $teamIds);
         $mapCollection = new Collection($mapArray);
         return $mapCollection->reject(function ($map_array) {
             return $map_array['picks_by'] + $map_array['picks_vs'] == 0;

--- a/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
+++ b/plugins/rikki/loungestatistics/classes/statistics/Statistics.php
@@ -207,21 +207,21 @@ class Statistics
 
     public static function calculateMapStatisticsForSloth($gameParticipations, $season)
     {
-        $participations = [];
+        $gameParticipationsInSeason = [];
         $teamIds = [];
         $i = 0;
         foreach ($gameParticipations as $gP) {
             if ($season == null || ($gP->game != null && $gP->game->match != null && $gP->game->match->belongsToSeason($season))) {
                 $teamId = $gP->team_id;
                 if ($gP->game != null && $teamId != null) {
-                    $participations[$i] = $gP;
+                    $gameParticipationsInSeason[$i] = $gP;
                     $teamIds[$i] = $teamId;
                     $i = $i + 1;
                 }
             }
         }
 
-        $mapArray = Self::analyzeGamesForMapStatsSloth($participations, $teamIds);
+        $mapArray = Self::analyzeGamesForMapStatsSloth($gameParticipationsInSeason, $teamIds);
         $mapCollection = new Collection($mapArray);
         return $mapCollection->reject(function ($map_array) {
             return $map_array['picks_by'] + $map_array['picks_vs'] == 0;

--- a/plugins/rikki/loungestatistics/components/SlothStatistics.php
+++ b/plugins/rikki/loungestatistics/components/SlothStatistics.php
@@ -33,7 +33,7 @@ class SlothStatistics extends ComponentBase
         $this->addCss('assets/css/datatables.min.css');
 
         $this->sloth = Sloth::where('id', $this->property('sloth_id'))
-            ->with('gameParticipations', 'gameParticipations.hero', 'gameParticipations.game', 'gameParticipations.game.gameParticipations', 'gameParticipations.game.map', 'gameParticipations.game.replay', 'gameParticipations.game.match.division.season', 'gameParticipations.game.teamOneFirstBan', 'gameParticipations.game.teamOneSecondBan', 'gameParticipations.game.teamOneThirdBan', 'gameParticipations.game.teamTwoFirstBan', 'gameParticipations.game.teamTwoSecondBan', 'gameParticipations.game.teamTwoThirdBan')
+            ->with('gameParticipations', 'gameParticipations.hero', 'gameParticipations.game', 'gameParticipations.game.map', 'gameParticipations.game.replay', 'gameParticipations.game.match.division.season', 'gameParticipations.game.teamOneFirstBan', 'gameParticipations.game.teamOneSecondBan', 'gameParticipations.game.teamOneThirdBan', 'gameParticipations.game.teamTwoFirstBan', 'gameParticipations.game.teamTwoSecondBan', 'gameParticipations.game.teamTwoThirdBan')
             ->first();
 
         $this->participatedSeasons = $this->sloth->gameParticipations

--- a/plugins/rikki/loungestatistics/components/SlothStatistics.php
+++ b/plugins/rikki/loungestatistics/components/SlothStatistics.php
@@ -33,7 +33,7 @@ class SlothStatistics extends ComponentBase
         $this->addCss('assets/css/datatables.min.css');
 
         $this->sloth = Sloth::where('id', $this->property('sloth_id'))
-            ->with('gameParticipations', 'gameParticipations.team', 'gameParticipations.game', 'gameParticipations.game.map', 'gameParticipations.game.match', 'gameParticipations.hero', 'gameParticipations.game.teamOneFirstBan', 'gameParticipations.game.teamOneSecondBan', 'gameParticipations.game.teamOneThirdBan', 'gameParticipations.game.teamTwoFirstBan', 'gameParticipations.game.teamTwoSecondBan', 'gameParticipations.game.teamTwoThirdBan')
+            ->with('gameParticipations', 'gameParticipations.hero', 'gameParticipations.game', 'gameParticipations.game.gameParticipations', 'gameParticipations.game.map', 'gameParticipations.game.replay', 'gameParticipations.game.match.division.season', 'gameParticipations.game.teamOneFirstBan', 'gameParticipations.game.teamOneSecondBan', 'gameParticipations.game.teamOneThirdBan', 'gameParticipations.game.teamTwoFirstBan', 'gameParticipations.game.teamTwoSecondBan', 'gameParticipations.game.teamTwoThirdBan')
             ->first();
 
         $this->participatedSeasons = $this->sloth->gameParticipations
@@ -51,7 +51,7 @@ class SlothStatistics extends ComponentBase
     }
 
     public function calculateStats($season)
-    {       
+    {
         $mapStats = Stats::calculateMapStatisticsForSloth($this->sloth->gameParticipations, $this->selectedSeason);
         $this->maps = $mapStats->sortByDesc(function ($map_array) {
             return $map_array['picks_by'] + $map_array['picks_vs'];

--- a/plugins/rikki/loungestatistics/components/TeamStatistics.php
+++ b/plugins/rikki/loungestatistics/components/TeamStatistics.php
@@ -37,7 +37,9 @@ class TeamStatistics extends ComponentBase
         $this->team = Team::where('id', $this->property('team_id'))
             ->with('matches', 'matches.division.season', 'matches.games', 'matches.games.replay', 'matches.games.map', 'matches.games.gameParticipations', 'matches.games.gameParticipations.hero', 'matches.games.teamOneFirstBan', 'matches.games.teamOneSecondBan', 'matches.games.teamTwoFirstBan', 'matches.games.teamTwoSecondBan', 'matches.games.teamOneThirdBan', 'matches.games.teamTwoThirdBan')
             ->first();
-        $this->participatedSeasons = $this->team->seasons
+        $this->participatedSeasons = $this->team->matches
+            ->map(function ($match) { return $match->season; })
+            ->filter(function ($season) { return $season != null; })
             ->groupBy('id')->map(function ($group) { return $group[0]; })  // unique does not work on these
             ->sortByDesc('created_at')->values();
 

--- a/plugins/rikki/loungestatistics/components/TeamStatistics.php
+++ b/plugins/rikki/loungestatistics/components/TeamStatistics.php
@@ -35,12 +35,9 @@ class TeamStatistics extends ComponentBase
         $this->addCss('assets/css/datatables.min.css');
 
         $this->team = Team::where('id', $this->property('team_id'))
-            ->with('matches', 'matches.games', 'matches.games.map', 'matches.games.gameParticipations', 'matches.games.gameParticipations.hero', 'matches.games.teamOneFirstBan', 'matches.games.teamOneSecondBan', 'matches.games.teamTwoFirstBan', 'matches.games.teamTwoSecondBan', 'matches.games.teamOneThirdBan', 'matches.games.teamTwoThirdBan')
+            ->with('matches', 'matches.division.season', 'matches.games', 'matches.games.replay', 'matches.games.map', 'matches.games.gameParticipations', 'matches.games.gameParticipations.hero', 'matches.games.teamOneFirstBan', 'matches.games.teamOneSecondBan', 'matches.games.teamTwoFirstBan', 'matches.games.teamTwoSecondBan', 'matches.games.teamOneThirdBan', 'matches.games.teamTwoThirdBan')
             ->first();
-
-        $this->participatedSeasons = $this->team->matches
-            ->map(function ($match) { return $match->season; })
-            ->filter(function ($season) { return $season != null; })
+        $this->participatedSeasons = $this->team->seasons
             ->groupBy('id')->map(function ($group) { return $group[0]; })  // unique does not work on these
             ->sortByDesc('created_at')->values();
 

--- a/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
+++ b/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
@@ -29,7 +29,7 @@
 
 <div class="row">
     <div class="col">
-        <span class="float-{% if __SELF__.game.getFirstPickTeam == __SELF__.game.teamOne.title %}left{% else %}right{% endif %} badge badge-info">
+        <span class="float-{% if __SELF__.game.getFirstPickTeamId == __SELF__.game.teamOne.id %}left{% else %}right{% endif %} badge badge-info">
             First Pick</span>
     </div>
 </div>

--- a/plugins/rikki/loungeviews/components/ViewTeam.php
+++ b/plugins/rikki/loungeviews/components/ViewTeam.php
@@ -28,8 +28,7 @@ class ViewTeam extends ComponentBase
     public function init()
     {
         $this->addCss('/plugins/martin/ssbuttons/assets/css/social-sharing-nb.css');
-        
-        $team = Teams::with('matches','matches.games','divisions','seasons')->where('slug', $this->param('slug'))->first();
+        $team = Teams::where('slug', $this->param('slug'))->first();
         if ($team) 
         {
             $this->team = $team;
@@ -50,7 +49,6 @@ class ViewTeam extends ComponentBase
                 [
                     'deferredBinding'   => true,
                     'surroundingEntries'    => 4
-
                 ]
             );
             $component = $this->addComponent(
@@ -58,8 +56,8 @@ class ViewTeam extends ComponentBase
                             'upcomingMatches',
                             [
                                 'deferredBinding'   => true,
-                                'daysInFuture'           => $this->property('daysInFuture'),
-                                'showLogo'          => true,
+                                'daysInFuture'  => $this->property('daysInFuture'),
+                                'showLogo'  => true,
                                 'showName' => false,
                                 'type' => 'team',
                                 'showCasters' => false,
@@ -99,9 +97,6 @@ class ViewTeam extends ComponentBase
                 ]
             );
         }
-    }
-    public function onRun()
-    {
     }
 
     public function defineProperties()

--- a/plugins/rikki/loungeviews/components/viewteam/default.htm
+++ b/plugins/rikki/loungeviews/components/viewteam/default.htm
@@ -182,7 +182,7 @@
                             <div class="tab-pane" id="teamStatistics" role="tabpanel">
                                 <!-- START Teamstatics -->
                                 {% component 'teamStatistics' %}
-                                <!-- END Teamstatics -->
+                                <!-- END Teamstatistics -->
                             </div>
                             <div class="tab-pane" id="activeSeasonMatches" role="tabpanel">
                                 <!-- START ROUND MATCHES -->


### PR DESCRIPTION
Improves performance significantly of loading statistics for sloths and teams on the front-end pages. This is likely one of our CPU time culprits...

In my dev environment `view/team` and `user/view` pages could take up to 2s to complete for some vs <1s now.