### PR TITLE
Update fetch images

### DIFF
--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -13,7 +13,6 @@ class HeroUpdater
 {
     public static function updateHeroes()
     {
-        set_time_limit(600);
         $theme = Theme::getActiveTheme();
         $theme_path = $theme->getPath();
         defined('DS') or define('DS', DIRECTORY_SEPARATOR);
@@ -21,253 +20,67 @@ class HeroUpdater
         if (!file_exists($hero_image_path)) {
             mkdir($hero_image_path, 0777, true);
         }
-        
-        $ch = curl_init("https://api.hotslogs.com/Public/Data/Heroes");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $hero_list_json = curl_exec($ch);
-        curl_close($ch);
-        $hero_list = json_decode($hero_list_json, true);
-        foreach ($hero_list as $hero_entry) {
-            if (Hero::where('title', $hero_entry['PrimaryName'])->count() == 0) {
-                $ch2 = curl_init("https://d1i1jxrdh2kvwy.cloudfront.net/Images/Heroes/Portraits/".urlencode($hero_entry['ImageURL']).".png");
-                curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-                $hero_portrait = curl_exec($ch2);
-                curl_close($ch2);
-                $file = fopen($hero_image_path.DS.$hero_entry['ImageURL'].".png", "w+");
+
+        $hero_list = SELF::getHeroesList();
+        foreach($hero_list as $hero_entry) {
+            if (Hero::where('title', $hero_entry['name'])->count() == 0) {
+                $heroData = Self::getHero($hero_entry['short_name']);
+                $hero_portrait = Self::getHeroImage($hero_entry['short_name']);
+
+                $localImageUrl = ucfirst($hero_entry['short_name']);
+                $file = fopen($hero_image_path.DS.$localImageUrl.".png", "w+");
                 fputs($file, $hero_portrait);
                 fclose($file);
+
                 $hero = new Hero();
-                $hero->title = $hero_entry['PrimaryName'];
-                $hero->image_url = $hero_entry['ImageURL'];
-                $hero->attribute_name = $hero_entry['AttributeName'];
-                $hero->translations = $hero_entry['Translations'];
-                $hero->save();
-            } else {
-                $hero = Hero::where('title', $hero_entry['PrimaryName'])->firstOrFail();
-                $hero->translations = $hero_entry['Translations'];
+                $hero->title = $hero_entry['name'];
+                $hero->image_url = $localImageUrl;
+                $hero->attribute_name = $hero_data['attributeId'];
+                $hero->translations = implode(",", $hero_entry['translations']);
                 $hero->save();
             }
         }
-        HeroUpdater::updateTalents();
-    }
 
-    //deprecated?
-    public static function updateTalentsHotslogs($hero)
-    {
-        set_time_limit(60);
-        defined('htmldom') or (include('simple_html_dom.php'));
-        defined('htmldom') or define('htmldom',0);
-        $ch = curl_init("https://www.hotslogs.com/Sitewide/HeroDetails?Hero=".urlencode($hero->title));
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $html_response = curl_exec($ch);
-        curl_close($ch);
-        $html = str_get_html($html_response);
-        $c = 0;
-        $talents = [];
-        foreach($html->find('div#talentDetails div#ctl00_MainContent_ctl00_MainContent_RadGridHeroTalentStatisticsPanel div table tbody tr') as $tab) {
-            $c++;
-            $tier = 0;
-            $choice = 0;
-            //skip first (header)
-            if ($c == 1) {
-                continue;
-            }
-            //now, we have either a talent or a level x subheader
-            if ($tab->find('td span.rgGroupHeaderText')) {
-                //level x subheader
-                $tier++;
-                $choice = 0;
-            } else {
-                $choice++;
-                $image_url = null;
-                foreach ($tab->find('img') as $imag) {
-                    $image_url = 'https:'.$imag->src;
-                }
-                $talent_title = $tab->find('td')[3]->innertext;
-                $talents[] = ['tier' => $tier, 'choice' => $choice, 'name' => $talent_title, 'icon' => ['small' => $image_url]];
-                //trigger_error(json_encode(['tier' => $tier, 'choice' => $choice, 'name' => $talent_title, 'icon' => ['small' => $image_url]]));
-            }
-        }
-        //trigger_error($talents[8]['icon']['small']);
-        return ['talents' => $talents];
-    }
-
-    public static function updateTalentsHotsAPI()
-    {
-        $theme = Theme::getActiveTheme();
-        $theme_path = $theme->getPath();
-        defined('DS') or define('DS', DIRECTORY_SEPARATOR);
-        $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
-        if (!file_exists($talent_image_path)) {
-            mkdir($talent_image_path, 0777, true);
-        }
-        $ch = curl_init("http://hotsapi.net/api/v1/heroes");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $response = curl_exec($ch);
-        curl_close($ch);
-        $decoded_heroes = json_decode($response, true);
-        foreach ($decoded_heroes as $hero) {
-            set_time_limit(30);
-            $heroModel = Hero::where('title', $hero['name'])->first();
-            if ($heroModel != null) {
-                foreach ($hero['talents'] as $talent) {
-                    if (Talent::where('title', $talent['title'])->where('hero_id', $heroModel->id)->count() == 0) {
-                        $tal = new Talent;
-                        $tal->hero = $heroModel;
-                        $tal->title = $talent['title'];
-                        $temp_string_array = explode('/', $talent['icon_url']['64x64']);
-                        $tal->image_url = end($temp_string_array);
-                        $talent_url = "https://cdn.hotstat.us/images/" . end($temp_string_array);
-                        $ch2 = curl_init($talent_url);
-                        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-                        $talent_icon = curl_exec($ch2);
-                        $contentType = curl_getinfo($ch2, CURLINFO_CONTENT_TYPE);
-                        curl_close($ch2);
-                        if ($contentType != 'application/xml') {
-                            $file = fopen($talent_image_path.DS.$tal->image_url, "w+");
-                            fputs($file, $talent_icon);
-                            fclose($file);
-                            Resizer::open($talent_image_path.DS.$tal->image_url)
-                                ->resize(32, 32)
-                                ->save($talent_image_path.DS.$tal->image_url, 100);
-                        } else {
-                            Log::error('Failed to get image for talent '.$talent['title']);
-                        }
-                        
-                        $tal->suspected_replay_title = preg_replace("/[^A-Za-z0-9]/", '', $tal->title);
-                        $tal->replay_title = $talent['name'];
-                        $tal->save();
-                        Log::info('New talent added: '.$talent['title']);
-                    } elseif (Talent::where('title', $talent['title'])->where('hero_id', $heroModel->id)->where('replay_title', 'IS NOT', 'NULL')->count() == 0) {
-                        $tal = Talent::where('title', $talent['title'])->where('hero_id', $heroModel->id)->firstOrFail();
-                        $tal->replay_title = $talent['name'];
-                        $tal->save();
-                    }
-                }
-            } else {
-                Log::error('Could not find hero '. $hero['name'] .' while updating talents!');
-            }
-        }
-    }
-
-    public static function getImages($hid)
-    {
-        $theme = Theme::getActiveTheme();
-        $theme_path = $theme->getPath();
-        defined('DS') or define('DS', DIRECTORY_SEPARATOR);
-        $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
-        if (!file_exists($talent_image_path)) {
-            mkdir($talent_image_path, 0777, true);
-        }
-        $ch = curl_init("http://hotsapi.net/api/v1/heroes");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $response = curl_exec($ch);
-        curl_close($ch);
-        $decoded_heroes = json_decode($response, true);
-        foreach ($decoded_heroes as $hero) {
-            set_time_limit(30);
-            $heroModel = Hero::where('title', $hero['name'])->first();
-            if ($heroModel != null && $heroModel->id == $hid) {
-                foreach ($hero['talents'] as $talent) {
-                    if (Talent::where('title', $talent['title'])->where('hero_id', $heroModel->id)->count() == 0) {
-                        $tal = new Talent;
-                        $tal->hero = $heroModel;
-                        $tal->title = $talent['title'];
-                        $tal->suspected_replay_title = preg_replace("/[^A-Za-z0-9]/", '', $tal->title);
-                        $tal->replay_title = $talent['name'];
-                        $temp_string_array = explode('/', $talent['icon_url']['64x64']);
-                        $tal->image_url = end($temp_string_array);
-                        $talent_url = "http://s3.hotsapi.net/img/talents/64x64/" . end($temp_string_array);
-                        $ch2 = curl_init($talent_url);
-                        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-                        $talent_icon = curl_exec($ch2);
-                        $contentType = curl_getinfo($ch2, CURLINFO_CONTENT_TYPE);
-                        curl_close($ch2);
-                        $tal->save();
-                        if ($contentType != 'application/xml') {
-                            $file = fopen($talent_image_path.DS.$tal->image_url, "w+");
-                            fputs($file, $talent_icon);
-                            fclose($file);
-                            Resizer::open($talent_image_path.DS.$tal->image_url)
-                                ->resize(32, 32)
-                                ->save($talent_image_path.DS.$tal->image_url, 100);
-                        } else {
-                            //Log::error('Failed to get image for talent '.$talent['title']);
-                            $hotslogs_title = substr($talent['name'], strlen($heroModel->title));
-                            HeroUpdater::fetchHotslogsImage($tal, $hotslogs_title, $talent['title'], end($temp_string_array), $tal->suspected_replay_title);
-                        }
-                        
-                        
-                        Log::info('New talent added: '.$talent['title']);
-                    } else {
-                        //just update image
-                        $temp_string_array = explode('/', $talent['icon_url']['64x64']);
-                        $talent_url = "http://s3.hotsapi.net/img/talents/64x64/" . end($temp_string_array);
-                        $ch2 = curl_init($talent_url);
-                        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-                        $talent_icon = curl_exec($ch2);
-                        $contentType = curl_getinfo($ch2, CURLINFO_CONTENT_TYPE);
-                        curl_close($ch2);
-                        if ($contentType != 'application/xml') {
-                            $file = fopen($talent_image_path.DS.end($temp_string_array), "w+");
-                            fputs($file, $talent_icon);
-                            fclose($file);
-                            Resizer::open($talent_image_path.DS.end($temp_string_array))
-                                ->resize(32, 32)
-                                ->save($talent_image_path.DS.end($temp_string_array), 100);
-                        } else {
-                            $hotslogs_title = substr($talent['name'], strlen($heroModel->title));
-                            HeroUpdater::fetchHotslogsImage(Talent::where('title', $talent['title'])->where('hero_id', $heroModel->id)->firstOrFail(), $hotslogs_title, $talent['title'], end($temp_string_array), preg_replace("/[^A-Za-z0-9]/", '', $talent['title']));
-                        }
-                    }  
-                }
-            }
-        }
+        Self::updateTalents();
     }
 
     public static function updateTalents()
     {
-        HeroUpdater::updateTalentsHotsAPI();
+        $hero_list = SELF::getHeroesList();
+        foreach($hero_list as $hero_entry) {
+            $heroModel = Hero::where('title', $hero_entry['name'])->first();
+            if ($heroModel != null) {
+                Self::updateTalentsForHero($heroModel, $hero_entry['short_name']);
+            } else {
+                Log::error('Could not find hero '. $hero_entry['name'] .' while updating talents!');
+            }
+        }
     }
 
-    public static function getHeroHotsAPI($hero)
+    public static function updateTalentsForHero($heroModel, $heroShortName)
     {
-        $ch = curl_init("http://hotsapi.net/api/v1/heroes/".urlencode($hero->title));
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $response = curl_exec($ch);
-        curl_close($ch);
-        return json_decode($response, true);
-    }
-
-    public static function updateTalentsForHero($hero, $version = null)
-    {
-    	$theme = Theme::getActiveTheme();
+        $theme = Theme::getActiveTheme();
         $theme_path = $theme->getPath();
         defined('DS') or define('DS', DIRECTORY_SEPARATOR);
         $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
         if (!file_exists($talent_image_path)) {
             mkdir($talent_image_path, 0777, true);
         }
-        set_time_limit(60);
-        $decoded_hero = HeroUpdater::getHeroHotsAPI($hero);
-        if (array_key_exists('talents', $decoded_hero)) {
-            foreach ($decoded_hero['talents'] as $talent) {
-                if (Talent::where('title', $talent['title'])->where('hero_id', $hero->id)->count() == 0) {
 
-                    $ch2 = curl_init($talent['icon_url']['64x64']);
-                    curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-                    $talent_icon = curl_exec($ch2);
-                    $contentType = curl_getinfo($ch2, CURLINFO_CONTENT_TYPE);
-                    curl_close($ch2);
-
+        $hero = Self::getHero($heroShortName);
+        foreach($hero['talents'] as $talentTier) {
+            foreach($talentTier as $talent) {
+                if (Talent::where('title', $talent['name'])->where('hero_id', $heroModel->id)->count() == 0) {
                     $tal = new Talent;
-                    $tal->hero = $hero;
-                    $tal->title = $talent['title'];
-                    $tal->suspected_replay_title = preg_replace("/[^A-Za-z0-9]/", '', $tal->title);
-                    $tal->replay_title = $talent['name'];
-                    $temp_string_array = explode('/', $talent['icon_url']['64x64']);
-                    $tal->image_url = end($temp_string_array);
-                    $tal->save();
+                    $tal->hero = $heroModel;
+                    $tal->title = $talent['name'];
+                    $tal->image_url = $talent['icon'];
+    
+                    $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/talents/" . urlencode($talent['icon']));
+                    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                    $talent_icon = curl_exec($ch);
+                    $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+                    curl_close($ch);
                     if ($contentType != 'application/xml') {
                         $file = fopen($talent_image_path.DS.$tal->image_url, "w+");
                         fputs($file, $talent_icon);
@@ -276,168 +89,77 @@ class HeroUpdater
                             ->resize(32, 32)
                             ->save($talent_image_path.DS.$tal->image_url, 100);
                     } else {
-                        //Log::error('Failed to get image for talent '.$talent['title']);
-                        $hotslogs_title = substr($talent['name'], strlen($hero->title));
-                        HeroUpdater::fetchHotslogsImage($tal, $hotslogs_title, $talent['title'], end($temp_string_array), preg_replace("/[^A-Za-z0-9]/", '', $talent['title']));
+                        Log::error('Failed to get image for talent '.$talent['name']);
                     }
                     
-                    
-                    
-                    Log::info('New talent added: '.$talent['title']);
-                } elseif (Talent::where('title', $talent['title'])->where('hero_id', $hero->id)->where('replay_title', 'IS NOT', 'NULL')->count() == 0) {
-                    $tal = Talent::where('title', $talent['title'])->where('hero_id', $hero->id)->firstOrFail();
+                    $tal->suspected_replay_title = preg_replace("/[^A-Za-z0-9]/", '', $tal->title);
                     $tal->replay_title = $talent['name'];
+                    $tal->save();
+                    Log::info('New talent added: '.$talent['name']);
+                } elseif (Talent::where('title', $talent['name'])->where('hero_id', $heroModel->id)->where('replay_title', 'IS NOT', 'NULL')->count() == 0) {
+                    $tal = Talent::where('title', $talent['name'])->where('hero_id', $heroModel->id)->firstOrFail();
+                    $tal->replay_title = $talent['talentTreeId'];
                     $tal->save();
                 }
             }
-            return $decoded_hero;
-        } else {
-            Log::error('No talents found during talent update: '.json_encode($decoded_hero));
-            return null;
         }
     }
 
-    public static function fetchHotslogsImage($talent, $talent_name, $talent_title, $image_url, $secondTalentName) {
-        Log::info("Trying hotslogs for ".$talent_title." ".$image_url." ".$secondTalentName);
-        $theme = Theme::getActiveTheme();
-        $theme_path = $theme->getPath();
-        defined('DS') or define('DS', DIRECTORY_SEPARATOR);
-        $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
-
-        $ch2 = curl_init("https://d1i1jxrdh2kvwy.cloudfront.net/Images/Talents/".$talent_name.".png");
-        curl_setopt($ch2, CURLOPT_RETURNTRANSFER, true);
-        $talent_icon = curl_exec($ch2);
-        $contentType = curl_getinfo($ch2, CURLINFO_CONTENT_TYPE);
-        curl_close($ch2);
-        if ($contentType != 'application/xml') {
-            $file = fopen($talent_image_path.DS.$image_url, "w+");
-            fputs($file, $talent_icon);
-            fclose($file);
-            $talent->image_url = $image_url;
-            $talent->save();
-            Resizer::open($talent_image_path.DS.$image_url)
-                ->resize(32, 32)
-                ->save($talent_image_path.DS.$image_url, 100);
-        } else {
-            $ch3 = curl_init("https://d1i1jxrdh2kvwy.cloudfront.net/Images/Talents/".$secondTalentName.".png");
-            curl_setopt($ch3, CURLOPT_RETURNTRANSFER, true);
-            $talent_icon = curl_exec($ch3);
-            $contentType = curl_getinfo($ch3, CURLINFO_CONTENT_TYPE);
-            curl_close($ch3);
-            if ($contentType != 'application/xml') {
-                $file = fopen($talent_image_path.DS.$image_url, "w+");
-                fputs($file, $talent_icon);
-                fclose($file);
-                $talent->image_url = $image_url;
-                $talent->save();
-                Resizer::open($talent_image_path.DS.$image_url)
-                    ->resize(32, 32)
-                    ->save($talent_image_path.DS.$image_url, 100);
-            } else {
-                //final try
-                //capitalize
-                $final_name = preg_replace_callback('/(?<=( |-))./',
-                      function ($m) { return strtoupper($m[0]); },
-                      $talent_title);
-                //remove spaces
-                $final_name = preg_replace("/[^A-Za-z0-9]/", '', $final_name);
-
-                $ch4 = curl_init("https://d1i1jxrdh2kvwy.cloudfront.net/Images/Talents/".$final_name.".png");
-                curl_setopt($ch4, CURLOPT_RETURNTRANSFER, true);
-                $talent_icon = curl_exec($ch4);
-                $contentType = curl_getinfo($ch4, CURLINFO_CONTENT_TYPE);
-                curl_close($ch4);
-                if ($contentType != 'application/xml') {
-                    $file = fopen($talent_image_path.DS.$image_url, "w+");
-                    fputs($file, $talent_icon);
-                    fclose($file);
-                    $talent->image_url = $image_url;
-                    $talent->save();
-                    Resizer::open($talent_image_path.DS.$image_url)
-                        ->resize(32, 32)
-                        ->save($talent_image_path.DS.$image_url, 100);
-                } else {
-                    Log::error('Failed to get image for talent '.$talent_name);
-                }
+    public static function addTranslationsToHeroes()
+    {
+        $hero_list = Self::getHeroesList();
+        foreach ($hero_list as $hero_entry) {
+            $hero = Hero::where('title', $hero_entry['name'])->first();
+            if ($hero) {
+                $hero->translations = implode(",", $hero_entry['translations']);
+                $hero->save();
             }
         }
     }
 
     public static function getHeroesList()
     {
-        sleep(1);
-    	$ch = curl_init("https://api.masterleague.net/heroes/?format=json");
-    	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    	$hero_list_json = curl_exec($ch);
-    	curl_close($ch);
-    	$decoded = json_decode($hero_list_json, true);
-    	$hero_list = $decoded['results'];
-    	while (array_key_exists('next', $decoded) && $decoded['next'] != null) {
-    		sleep(1);
-    		$ch = curl_init($decoded['next']);
-    		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    		$hero_list_json = curl_exec($ch);
-    		curl_close($ch);
-    		$decoded = json_decode($hero_list_json, true);
-    		$hero_list = array_merge($hero_list, $decoded['results']);
-    	}
-    	return $hero_list;
-    }
-
-    public static function addMasterleagueIds()
-    {
-    	$hero_list = HeroUpdater::getHeroesList();
-    	foreach ($hero_list as $hero_entry) {
-    		$hero = Hero::where('title', $hero_entry['name'])->first();
-    		if ($hero) {
-    			$hero->masterleague_id = $hero_entry['id'];
-    		} else {
-    			$hero = Hero::where('translations', 'LIKE', '%'.$hero_entry['name'].'%')->first();
-    			if ($hero) {
-    				$hero->masterleague_id = $hero_entry['id'];
-    			} else {
-    				trigger_error($hero_entry['name']);
-    			}
-    		}
-    		$hero->save();
-    	}
-    }
-
-    public static function addTranslationsToHeroes()
-    {
-        set_time_limit(600);
-
-        $ch = curl_init("https://api.hotslogs.com/Public/Data/Heroes");
+        $ch = curl_init("https://api.heroesprofile.com/openApi/Heroes");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $hero_list_json = curl_exec($ch);
         curl_close($ch);
         $hero_list = json_decode($hero_list_json, true);
 
-        foreach ($hero_list as $hero_entry) {
-            $hero = Hero::where('title', $hero_entry['PrimaryName'])->first();
-            if ($hero) {
-                $hero->translations = $hero_entry['Translations'];
-                $hero->save();
-            }
-        }
+        return $hero_list;
     }
 
-    public static function addTranslationsToMaps()
+    public static function getHero($hero_name)
     {
-        set_time_limit(600);
-
-        $ch = curl_init("https://api.hotslogs.com/Public/Data/Maps");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        $map_list_json = curl_exec($ch);
-        curl_close($ch);
-        $map_list = json_decode($map_list_json, true);
-
-        foreach ($map_list as $map_entry) {
-            $map = Map::where('title', $map_entry['PrimaryName'])->first();
-            if ($map) {
-                $map->translations = $map_entry['Translations'];
-                $map->save();
-            }
+        // There are naming exceptions for TLV and Cho.
+        if ($hero_name == 'thelostvikings') {
+            $hero_name = 'lostvikings';
+        } else if ($hero_name == 'cho') {
+            $hero_name = 'chogall';
         }
+
+        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/hero/" . urlencode($hero_name) . ".json");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $hero_json = curl_exec($ch);
+        curl_close($ch);
+        $hero = json_decode($hero_json, true);
+
+        return $hero;
+    }
+
+    public static function getHeroImage($hero_name)
+    {
+        // There are naming exceptions for TLV and Cho.
+        if ($hero_name == 'thelostvikings') {
+            $hero_name = 'lostvikings';
+        } else if ($hero_name == 'cho') {
+            $hero_name = 'chogall';
+        }
+
+        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/heroes/" . urlencode($hero_name) . ".png");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $hero_portrait = curl_exec($ch);
+        curl_close($ch);
+        
+        return $hero_portrait;
     }
 }

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -22,7 +22,7 @@ class HeroUpdater
                 $hero->image_url = ucfirst($hero_entry['short_name']);
                 $hero->attribute_name = $hero_data['attributeId'];
                 $hero->translations = implode(",", $hero_entry['translations']);
-                Self::saveHeroImage($hero_entry['short_name']);
+                Self::addHeroImage($hero_entry['short_name']);
                 $hero->save();
             }
         }
@@ -53,7 +53,7 @@ class HeroUpdater
                     $talent->hero = $hero_model;
                     $talent->title = $talent_data['name'];
                     $talent->image_url = $talent_data['icon'];
-                    Self::saveTalentImage($talent->image_url);
+                    Self::addTalentImage($talent->image_url);
 
                     $talent->replay_title = $talent_data['talentTreeId'];
                     $talent->save();
@@ -63,7 +63,7 @@ class HeroUpdater
                     $talent = Talent::where('replay_title', $talent_data['talentTreeId'])->where('hero_id', $hero_model->id)->firstOrFail();
                     $talent->title = $talent_data['name'];
                     $talent->image_url = $talent_data['icon'];
-                    Self::saveTalentImage($talent->image_url);
+                    Self::addTalentImage($talent->image_url);
                     $talent->save();
                 }
             }
@@ -105,7 +105,7 @@ class HeroUpdater
         return $hero;
     }
 
-    public static function saveTalentImage($icon_url)
+    public static function addTalentImage($icon_url)
     {
         $theme = Theme::getActiveTheme();
         $theme_path = $theme->getPath();
@@ -132,7 +132,7 @@ class HeroUpdater
         }
     }
 
-    public static function saveHeroImage($hero_short_name)
+    public static function addHeroImage($hero_short_name)
     {
         $theme = Theme::getActiveTheme();
         $theme_path = $theme->getPath();

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -72,7 +72,7 @@ class HeroUpdater
                     $talent->replay_title = $talent_data['talentTreeId'];
                     $talent->save();
                     Log::info('New talent added: '.$talent_data['name']);
-                } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->count() == 1) {
+                } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->first()) {
                     // We encountered this talent earlier during replay parsing, but weren't able to populate all of it's data at the time.
                     $talent = Talent::where('replay_title', $talent_data['talentTreeId'])->where('hero_id', $heroModel->id)->firstOrFail();
                     $talent->title = $talent_data['name'];

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -59,14 +59,6 @@ class HeroUpdater
 
     public static function updateTalentsForHero($heroModel, $heroShortName)
     {
-        $theme = Theme::getActiveTheme();
-        $theme_path = $theme->getPath();
-        defined('DS') or define('DS', DIRECTORY_SEPARATOR);
-        $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
-        if (!file_exists($talent_image_path)) {
-            mkdir($talent_image_path, 0777, true);
-        }
-
         $hero = Self::getHero($heroShortName);
         foreach($hero['talents'] as $talentTier) {
             foreach($talentTier as $talent_data) {
@@ -75,30 +67,17 @@ class HeroUpdater
                     $talent->hero = $heroModel;
                     $talent->title = $talent_data['name'];
                     $talent->image_url = $talent_data['icon'];
-    
-                    $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/talents/" . urlencode($talent_data['icon']));
-                    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                    $talent_icon = curl_exec($ch);
-                    $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
-                    curl_close($ch);
-                    if ($contentType != 'application/xml') {
-                        $file = fopen($talent_image_path.DS.$talent->image_url, "w+");
-                        fputs($file, $talent_icon);
-                        fclose($file);
-                        Resizer::open($talent_image_path.DS.$talent->image_url)
-                            ->resize(32, 32)
-                            ->save($talent_image_path.DS.$talent->image_url, 100);
-                    } else {
-                        Log::error('Failed to get image for talent '.$talent_data['name']);
-                    }
-                    
-                    $talent->replay_title = $talent_data['name'];
+                    Self::saveTalentImage($talent->image_url);
+
+                    $talent->replay_title = $talent_data['talentTreeId'];
                     $talent->save();
                     Log::info('New talent added: '.$talent_data['name']);
-                } elseif (Talent::where('title', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', 'IS NOT', 'NULL')->count() == 0) {
-                    // Check if the talent has replay_title data, which we need to identify talents during replay parsing.
-                    $talent = Talent::where('title', $talent_data['name'])->where('hero_id', $heroModel->id)->firstOrFail();
-                    $talent->replay_title = $talent_data['talentTreeId'];
+                } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->count() == 0) {
+                    // We encountered a new talent earlier during replay parsing, but weren't able to populate all of it's data at the time.
+                    $talent = Talent::where('replay_title', $talent_data['talentTreeId'])->where('hero_id', $heroModel->id)->firstOrFail();
+                    $talent->title = $talent_data['name'];
+                    $talent->image_url = $talent_data['icon'];
+                    Self::saveTalentImage($talent->image_url);
                     $talent->save();
                 }
             }
@@ -130,8 +109,8 @@ class HeroUpdater
 
     public static function getHero($hero_name)
     {
-        $hero_name = Self::getHeroNameForHeroesPatchNotes($hero_name);
-        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/hero/" . urlencode($hero_name) . ".json");
+        $hpn_hero_name = Self::getHeroNameForHeroesPatchNotes($hero_name);
+        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/hero/" . urlencode($hpn_hero_name) . ".json");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $hero_json = curl_exec($ch);
         curl_close($ch);
@@ -140,10 +119,37 @@ class HeroUpdater
         return $hero;
     }
 
+    public static function saveTalentImage($icon_url)
+    {
+        $theme = Theme::getActiveTheme();
+        $theme_path = $theme->getPath();
+        defined('DS') or define('DS', DIRECTORY_SEPARATOR);
+        $talent_image_path = $theme_path.DS.'assets'.DS.'img'.DS.'talents';
+        if (!file_exists($talent_image_path)) {
+            mkdir($talent_image_path, 0777, true);
+        }
+
+        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/talents/" . urlencode($icon_url));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $talent_icon = curl_exec($ch);
+        $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+        curl_close($ch);
+        if ($contentType != 'application/xml') {
+            $file = fopen($talent_image_path.DS.$icon_url, "w+");
+            fputs($file, $talent_icon);
+            fclose($file);
+            Resizer::open($talent_image_path.DS.$icon_url)
+                ->resize(32, 32)
+                ->save($talent_image_path.DS.$icon_url, 100);
+        } else {
+            Log::error('Failed to get image for talent icon '. $icon_url);
+        }
+    }
+
     public static function getHeroImage($hero_name)
     {
-        $hero_name = Self::getHeroNameForHeroesPatchNotes($hero_name);
-        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/heroes/" . urlencode($hero_name) . ".png");
+        $hpn_hero_name = Self::getHeroNameForHeroesPatchNotes($hero_name);
+        $ch = curl_init("https://heroespatchnotes.github.io/heroes-talents/images/heroes/" . urlencode($hpn_hero_name) . ".png");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $hero_portrait = curl_exec($ch);
         curl_close($ch);
@@ -154,9 +160,9 @@ class HeroUpdater
     public static function getHeroNameForHeroesPatchNotes($hero_name)
     {
         if ($hero_name == 'thelostvikings') {
-            $hero_name = 'lostvikings';
+            return 'lostvikings';
         } else if ($hero_name == 'cho') {
-            $hero_name = 'chogall';
+            return 'chogall';
         }
 
         return $hero_name;

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -72,7 +72,7 @@ class HeroUpdater
                     $talent->replay_title = $talent_data['talentTreeId'];
                     $talent->save();
                     Log::info('New talent added: '.$talent_data['name']);
-                } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->count() == 0) {
+                } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->count() == 1) {
                     // We encountered this talent earlier during replay parsing, but weren't able to populate all of it's data at the time.
                     $talent = Talent::where('replay_title', $talent_data['talentTreeId'])->where('hero_id', $heroModel->id)->firstOrFail();
                     $talent->title = $talent_data['name'];

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -73,7 +73,7 @@ class HeroUpdater
                     $talent->save();
                     Log::info('New talent added: '.$talent_data['name']);
                 } elseif (Talent::where('title', 'IS NOT', $talent_data['name'])->where('hero_id', $heroModel->id)->where('replay_title', $talent_data['talentTreeId'])->count() == 0) {
-                    // We encountered a new talent earlier during replay parsing, but weren't able to populate all of it's data at the time.
+                    // We encountered this talent earlier during replay parsing, but weren't able to populate all of it's data at the time.
                     $talent = Talent::where('replay_title', $talent_data['talentTreeId'])->where('hero_id', $heroModel->id)->firstOrFail();
                     $talent->title = $talent_data['name'];
                     $talent->image_url = $talent_data['icon'];

--- a/plugins/rikki/heroeslounge/models/Map.php
+++ b/plugins/rikki/heroeslounge/models/Map.php
@@ -23,9 +23,4 @@ class Map extends Model
      * @var string The database table used by the model.
      */
     public $table = 'rikki_heroeslounge_maps';
-
-    public function afterCreate()
-    {
-        Rikki\Heroeslounge\classes\Heroes\HeroUpdater::addTranslationsToMaps();
-    }
 }


### PR DESCRIPTION
Refactors Heroes and Talents image fetching by making use of actively maintained sources.

Uses [Heroes Profile API](https://api.heroesprofile.com/) to get a list of all current heroes. This source also provides us with the translation data for heroes.

Uses [Heroes Patchnotes](https://github.com/heroespatchnotes/heroes-talents) as the image source, as they have the most complete data set as well as hero `attribute_names` used during replay parsing.

For both of the above sources, the data is always of the current game version. From what I could tell, there aren't any data sources offering the ability to query data for a specific game version. As a result we may be unable to retrieve all the information on older talents.

Heroes Patchnotes doesn't discard images for removed talents, so they're all still there in their repository.