### PR TITLE
Lazyload images on supported browsers

### DIFF
--- a/plugins/rikki/heroeslounge/components/roundmatches/showMatchGroup.htm
+++ b/plugins/rikki/heroeslounge/components/roundmatches/showMatchGroup.htm
@@ -8,7 +8,7 @@
                     <div class="col-2 d-xs-none">
                         {%  if match.teams[0].logo.path %}
                         <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                             alt="{{match.teams[0].title}} Logo" title="{{match.teams[0].title}} Logo" loading=lazy /> {% endif %}
+                             alt="{{match.teams[0].title}} Logo" title="{{match.teams[0].title}} Logo" loading="lazy" /> {% endif %}
                     </div>
                     <div class="col-8 font-weight-bold hideOverflow f100">
                         <a href="{{ 'team/view'|page({ slug: match.teams[0].slug }) }}" title="Match Details">{{match.teams[0].title}}</a>
@@ -34,7 +34,7 @@
                     <div class="col-2 d-xs-none">
                         {%  if match.teams[1].logo.path != null %}
                         <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                             alt="{{match.teams[1].title}} Logo" title="{{match.teams[1].title}} Logo" loading=lazy /> {% endif %}
+                             alt="{{match.teams[1].title}} Logo" title="{{match.teams[1].title}} Logo" loading="lazy" /> {% endif %}
                     </div>
                 </div>
             </div>
@@ -45,7 +45,7 @@
                         <a href="{{ 'team/view'|page({ slug: match.teams[0].slug }) }}">
                             {% if match.teams[0].logo.path != null %}
                             <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                                alt="{{match.teams[0].title}} Logo" title="Click for {{match.teams[0].title}}'s Profile" loading=lazy />
+                                alt="{{match.teams[0].title}} Logo" title="Click for {{match.teams[0].title}}'s Profile" loading="lazy" />
                             {% else %}{{match.teams[0].title}}{% endif %}
                         </a>
                     </div>
@@ -68,7 +68,7 @@
                         <a href="{{ 'team/view'|page({ slug: match.teams[1].slug }) }}">
                             {% if match.teams[1].logo.path != null %}
                             <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                                alt="{{match.teams[1].title}} Logo" title="Click for {{match.teams[1].title}}'s Profile" loading=lazy />
+                                alt="{{match.teams[1].title}} Logo" title="Click for {{match.teams[1].title}}'s Profile" loading="lazy" />
                             {% else %}{{match.teams[1].title}}{% endif %}
                         </a>
                     </div>

--- a/plugins/rikki/heroeslounge/components/roundmatches/showMatchGroup.htm
+++ b/plugins/rikki/heroeslounge/components/roundmatches/showMatchGroup.htm
@@ -8,7 +8,7 @@
                     <div class="col-2 d-xs-none">
                         {%  if match.teams[0].logo.path %}
                         <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                             alt="{{match.teams[0].title}} Logo" title="{{match.teams[0].title}} Logo" /> {% endif %}
+                             alt="{{match.teams[0].title}} Logo" title="{{match.teams[0].title}} Logo" loading=lazy /> {% endif %}
                     </div>
                     <div class="col-8 font-weight-bold hideOverflow f100">
                         <a href="{{ 'team/view'|page({ slug: match.teams[0].slug }) }}" title="Match Details">{{match.teams[0].title}}</a>
@@ -34,7 +34,7 @@
                     <div class="col-2 d-xs-none">
                         {%  if match.teams[1].logo.path != null %}
                         <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
-                             alt="{{match.teams[1].title}} Logo" title="{{match.teams[1].title}} Logo" /> {% endif %}
+                             alt="{{match.teams[1].title}} Logo" title="{{match.teams[1].title}} Logo" loading=lazy /> {% endif %}
                     </div>
                 </div>
             </div>
@@ -42,9 +42,12 @@
             <div class="col-5 col-lg-5 hideOverflow">
                 <div class="row">
                     <div class="col-8 font-weight-bold hideOverflow f100">
-                        <a href="{{ 'team/view'|page({ slug: match.teams[0].slug }) }}">{% if match.teams[0].logo.path != null %}<img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px"
-                                                                                                                                    class="img-fluid" alt="{{match.teams[0].title}} Logo"
-                                                                                                                                    title="Click for {{match.teams[0].title}}'s Profile" />{% else %}{{match.teams[0].title}}{% endif %}</a>
+                        <a href="{{ 'team/view'|page({ slug: match.teams[0].slug }) }}">
+                            {% if match.teams[0].logo.path != null %}
+                            <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
+                                alt="{{match.teams[0].title}} Logo" title="Click for {{match.teams[0].title}}'s Profile" loading=lazy />
+                            {% else %}{{match.teams[0].title}}{% endif %}
+                        </a>
                     </div>
                     <div class="col-4">
                         <span class="f100 spoiler badge badge-{% if match.teams[0].id == match.winner_id %}success{% elseif match.teams[1].id == match.winner_id %}danger{% else %}warning{% endif %}">
@@ -62,9 +65,12 @@
             {{match.teams[1].pivot.team_score}}</span>
                     </div>
                     <div class="col-8 font-weight-bold hideOverflow f100">
-                        <a href="{{ 'team/view'|page({ slug: match.teams[1].slug }) }}">{% if match.teams[1].logo.path != null %}<img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px"
-                                                                                                                                    class="img-fluid" alt="{{match.teams[1].title}} Logo"
-                                                                                                                                    title="Click for {{match.teams[1].title}}'s Profile" />{% else %}{{match.teams[1].title}}{% endif %}</a>
+                        <a href="{{ 'team/view'|page({ slug: match.teams[1].slug }) }}">
+                            {% if match.teams[1].logo.path != null %}
+                            <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
+                                alt="{{match.teams[1].title}} Logo" title="Click for {{match.teams[1].title}}'s Profile" loading=lazy />
+                            {% else %}{{match.teams[1].title}}{% endif %}
+                        </a>
                     </div>
                 </div>
             </div>

--- a/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
+++ b/plugins/rikki/heroeslounge/components/upcomingmatches/default.htm
@@ -43,7 +43,8 @@
                 <div class="event-list--team row col-sm-12 col-md-3 row no-gutters">
                     <div class="event-list--teamlogo col-sm-6 col-md-3 px-1">
                         {% if match.teams[0].logo is not null %}
-                        <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid" alt="Team 1 Logo" title="Click for {{match.teams[0].title}} Profile" />
+                        <img src="{{match.teams[0].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid"
+                            alt="Team 1 Logo" title="Click for {{match.teams[0].title}} Profile" loading="lazy" />
                         {% endif %}
                     </div>
                     <div class="event-list--teamname col-sm-6 col-md-9 px-1">
@@ -56,7 +57,8 @@
                 <div class="event-list--team row col-sm-12 col-md-3 row no-gutters">
                     <div class="event-list--teamlogo col-sm-6 col-md-3 px-1">
                             {% if match.teams[1].logo is not null %}
-                            <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid hideOverflow" alt="Team 2 Logo" title="Click for {{match.teams[1].title}} Profile" />
+                            <img src="{{match.teams[1].logo.path | resize(64,64)}}" style="max-height: 26px" class="img-fluid hideOverflow"
+                                alt="Team 2 Logo" title="Click for {{match.teams[1].title}} Profile" loading="lazy" />
                             {% endif %}
                         </div>
                     <div class="event-list--teamname col-sm-6 col-md-9 px-1">

--- a/plugins/rikki/loungestatistics/components/GameStatistics.php
+++ b/plugins/rikki/loungestatistics/components/GameStatistics.php
@@ -29,7 +29,7 @@ class GameStatistics extends ComponentBase
     {
     
         $this->game = Game::find($this->property('game_id'));
-        $this->lazy = $this->property('lazy') == 'false' ? 'auto' : 'lazy';
+        $this->lazy = $this->property('lazy') ? 'lazy' : 'auto';
     }
 
 
@@ -48,8 +48,8 @@ class GameStatistics extends ComponentBase
             'lazy' => [
                 'title' => 'Lazy',
                 'description' => 'Whether to lazy load game images',
-                'default' => 'false',
-                'type' => 'string',
+                'default' => false,
+                'type' => 'checkbox',
             ]
             ];
     }

--- a/plugins/rikki/loungestatistics/components/GameStatistics.php
+++ b/plugins/rikki/loungestatistics/components/GameStatistics.php
@@ -27,12 +27,9 @@ class GameStatistics extends ComponentBase
 
     public function onRender()
     {
-    
         $this->game = Game::find($this->property('game_id'));
         $this->lazy = $this->property('lazy') ? 'lazy' : 'auto';
     }
-
-
 
     public function defineProperties()
     {
@@ -51,8 +48,6 @@ class GameStatistics extends ComponentBase
                 'default' => false,
                 'type' => 'checkbox',
             ]
-            ];
+        ];
     }
-
-
 }

--- a/plugins/rikki/loungestatistics/components/GameStatistics.php
+++ b/plugins/rikki/loungestatistics/components/GameStatistics.php
@@ -17,6 +17,7 @@ class GameStatistics extends ComponentBase
     }
 
     public $game = null;
+    public $lazy = false;
 
     public function init()
     {
@@ -28,6 +29,7 @@ class GameStatistics extends ComponentBase
     {
     
         $this->game = Game::find($this->property('game_id'));
+        $this->lazy = $this->property('lazy') == 'false' ? 'auto' : 'lazy';
     }
 
 
@@ -42,6 +44,12 @@ class GameStatistics extends ComponentBase
                 'type' => 'string',
                 'validationPattern' => '^[0-9]+$',
                 'validationMessage' => 'The game_id property can contain only numeric symbols'
+            ],
+            'lazy' => [
+                'title' => 'Lazy',
+                'description' => 'Whether to lazy load game images',
+                'default' => 'false',
+                'type' => 'string',
             ]
             ];
     }

--- a/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
+++ b/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
@@ -9,14 +9,14 @@
                     </a>
                 </h3>
             </div>
-            <img src="{% if __SELF__.game.teamOne.logo.path %}{{__SELF__.game.teamOne.logo.path}}{% else %}/plugins/rikki/heroeslounge/assets/img/profile-icon.png{% endif %}" class="d-flex align-self-start ml-2" style="max-height: 50px" alt="{{__SELF__.game.teamOne.title}}"
-                title="{{__SELF__.game.teamOne.title}}">
+            <img src="{% if __SELF__.game.teamOne.logo.path %}{{__SELF__.game.teamOne.logo.path}}{% else %}/plugins/rikki/heroeslounge/assets/img/profile-icon.png{% endif %}"
+                class="d-flex align-self-start ml-2" style="max-height: 50px" alt="{{__SELF__.game.teamOne.title}}" title="{{__SELF__.game.teamOne.title}}">
         </div>
     </div>
     <div class="col-6">
         <div class="media text-left">
-            <img src="{% if __SELF__.game.teamTwo.logo.path %}{{__SELF__.game.teamTwo.logo.path}}{% else %}/plugins/rikki/heroeslounge/assets/img/profile-icon.png{% endif %}" class="d-flex align-self-start mr-2" style="max-height: 50px" alt="{{__SELF__.game.teamTwo.title}}"
-                title="{{__SELF__.game.teamTwo.title}}">
+            <img src="{% if __SELF__.game.teamTwo.logo.path %}{{__SELF__.game.teamTwo.logo.path}}{% else %}/plugins/rikki/heroeslounge/assets/img/profile-icon.png{% endif %}"
+                class="d-flex align-self-start mr-2" style="max-height: 50px" alt="{{__SELF__.game.teamTwo.title}}" title="{{__SELF__.game.teamTwo.title}}">
             <div class="media-body">
                 <h3>
                     <a href="{{ 'team/view' |page({slug: __SELF__.game.teamTwo.slug})}}">
@@ -38,7 +38,7 @@
         {% for participant in __SELF__.game.getTeamOneParticipants %}
         <figure class="figure float-left m-1" style="max-width:70px">
             {% set path = 'assets/img/heroes/' ~ participant.hero.image_url ~ '.png' %}
-            <img src="{{path | theme}}" title="{{participant.hero.title}}" alt="{{participant.hero.title}}" class="rounded " />
+            <img src="{{path | theme}}" title="{{participant.hero.title}}" alt="{{participant.hero.title}}" class="rounded Icon75x" loading={{__SELF__.lazy}} />
             <figcaption class="figure-caption text-center text-truncate" title="{% if participant.sloth %}{{participant.sloth.title}}{% else %} {{participant.title}} {% endif %}">
                 {% if participant.sloth %}
                 <a href="{{ 'user/view' | page({id: participant.sloth.id})}}">
@@ -53,7 +53,7 @@
         {% for participant in __SELF__.game.getTeamTwoParticipants %}
         <figure class="figure float-right m-1" style="max-width:70px">
             {% set path = 'assets/img/heroes/' ~ participant.hero.image_url ~ '.png' %}
-            <img src="{{path | theme}}" title="{{participant.hero.title}}" alt="{{participant.hero.title}}" class="rounded " />
+            <img src="{{path | theme}}" title="{{participant.hero.title}}" alt="{{participant.hero.title}}" class="rounded Icon75x" loading={{__SELF__.lazy}} />
             <figcaption class="figure-caption text-center text-truncate" title="{% if participant.sloth %}{{participant.sloth.title}}{% else %} {{participant.title}} {% endif %}">
                 {% if participant.sloth %}
                 <a href="{{ 'user/view' | page({id: participant.sloth.id})}}">
@@ -78,18 +78,20 @@
         <figure class="figure float-left m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamOneFirstBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamOneFirstBan.title}}" alt="{{__SELF__.game.teamOneFirstBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
         <figure class="figure float-left m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamOneSecondBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamOneSecondBan.title}}" alt="{{__SELF__.game.teamOneSecondBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
+        {% if __SELF__.game.teamOneThirdBan %}
         <figure class="figure float-left m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamOneThirdBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamOneThirdBan.title}}" alt="{{__SELF__.game.teamOneThirdBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
+        {% endif %}
     </div>
     <div class="col">
         {% set map = 'assets/img/maps/bg_' ~__SELF__.game.map.title|replace({' ':'-'})|lower ~ '.jpg'%}
@@ -97,7 +99,8 @@
             <figure class="fixure mx-auto mb-0">
                 {% if __SELF__.game.replay %}
                     <a href="{{__SELF__.game.replay.path}}">
-                        <img src="{{ map| theme }}" class=" figure-img rounded" alt="{{game.map.title}}" title="Click to download the replay file" style="max-width:234px">
+                        <img src="{{ map| theme }}" class=" figure-img rounded" alt="{{game.map.title}}" title="Click to download the replay file"
+                            style="max-width:234px" loading={{__SELF__.lazy}}>
                     </a>
                     <figcaption class="figure-caption">
                         <span class="badge badge-info">{{__SELF__.game.map.title}}</span>
@@ -108,7 +111,8 @@
                         </a>
                     </figcaption>
                 {% else %}
-                    <img src="{{ map| theme }}" class=" figure-img rounded" alt="{{game.map.title}}" style="max-width:234px">
+                    <img src="{{ map| theme }}" class=" figure-img rounded" alt="{{game.map.title}}"
+                        style="max-width:234px" loading={{__SELF__.lazy}}>
                     <figcaption class="figure-caption">
                     <span class="badge badge-info">{{__SELF__.game.map.title}}</span>
                     </figcaption>
@@ -120,18 +124,20 @@
         <figure class="figure float-right m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamTwoFirstBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamTwoFirstBan.title}}" alt="{{__SELF__.game.teamTwoFirstBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
         <figure class="figure float-right m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamTwoSecondBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamTwoSecondBan.title}}" alt="{{__SELF__.game.teamTwoSecondBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
+        {% if __SELF__.game.teamTwoThirdBan %}
         <figure class="figure float-right m-1">
             {% set path = 'assets/img/heroes/' ~ __SELF__.game.teamTwoThirdBan.image_url ~ '.png' %}
             <img src="{{path | theme}}" title="{{__SELF__.game.teamTwoThirdBan.title}}" alt="{{__SELF__.game.teamTwoThirdBan.title}}"
-                class="rounded " />
+                class="rounded Icon75x" loading={{__SELF__.lazy}} />
         </figure>
+        {% endif %}
     </div>
 </div>
 
@@ -142,8 +148,8 @@
             <div class="card-header bg-primary">
                 <button class="btn btn-primary w-100" type="button" data-toggle="collapse" data-target="#game_{{__SELF__.game.id}}" aria-expanded="false"
                     aria-controls="collapseExample">
-                                    Toggle Statistics
-                            </button>
+                    Toggle Statistics
+                </button>
             </div>
             <div class="collapse" id="game_{{__SELF__.game.id}}">
                 <div class="row text-center align-middle mx-3 mt-2">
@@ -160,7 +166,7 @@
                                 <h1>{{__SELF__.game.getTeamOneKills}}</h1>
                             </div>
                             <div class="col-3">
-                                <img src="{{'assets/img/icons/crossed-swords.svg' |theme}}">
+                                <img src="{{'assets/img/icons/crossed-swords.svg' |theme}}" alt="" loading="lazy">
                             </div>
                         </div>
                     </div>
@@ -172,7 +178,7 @@
                         <div class="row">
 
                             <div class="col-3">
-                                <img src="{{'assets/img/icons/crossed-swords.svg' |theme}}">
+                                <img src="{{'assets/img/icons/crossed-swords.svg' |theme}}" alt="" loading="lazy">
                             </div>
                             <div class="col-3">
                                 <h1>{{__SELF__.game.getTeamTwoKills}}</h1>
@@ -209,13 +215,13 @@
                                 Player
                             </th>
                             <th class="text-center">
-                                <img src="{{ 'assets/img/icons/skull_swords.svg' | theme }}" class="Icon24x mx-1" title="Kills" alt="Kills" />
+                                <img src="{{ 'assets/img/icons/skull_swords.svg' | theme }}" class="Icon24x mx-1" title="Kills" alt="Kills" loading="lazy" />
                             </th>
                             <th class="text-center">
-                                <img src="{{ 'assets/img/icons/palm.svg' | theme }}" class="Icon24x mx-1" title="Assists" alt="Assists" />
+                                <img src="{{ 'assets/img/icons/palm.svg' | theme }}" class="Icon24x mx-1" title="Assists" alt="Assists" loading="lazy" />
                             </th>
                             <th class="text-center">
-                                <img src="{{ 'assets/img/icons/skull.svg' | theme }}" class="Icon24x mx-1" title="Deaths" alt="Deaths" />
+                                <img src="{{ 'assets/img/icons/skull.svg' | theme }}" class="Icon24x mx-1" title="Deaths" alt="Deaths" loading="lazy" />
                             </th>
                             <th class="text-center">
                                 Siege Dmg
@@ -241,15 +247,17 @@
                             ~ '.png' %}
                             <tr class="bg-{% if player.team.id == __SELF__.game.teamOne.id %}primary{% else %}danger{% endif %} text-white text-center">
                                 <th scope="row" class="text-center">
-                                    <img src="{{ path | theme}}" class="" alt="{{player.hero.title}}" title="{{player.hero.title}}" style="max-height:50px">
+                                    <img src="{{ path | theme}}" class="Icon50x" alt="{{player.hero.title}}" title="{{player.hero.title}}" loading="lazy">
                                     <p class="d-none">{{player.hero.title}}</p>
                                 </th>
                                 <td class="align-middle">
                                     {% if player.sloth %}
                                     <a href="{{'user/view' |page({id:player.sloth.id})}}" alt="Player Profile" class="text-white">
-                                                                {{player.title}}
-                                                            </a> {% else %}
-                                    <span class="text-dark">{{player.title}}</span> {% endif %}
+                                        {{player.title}}
+                                    </a>
+                                    {% else %}
+                                    <span class="text-dark">{{player.title}}</span>
+                                    {% endif %}
                                 </td>
                                 <td class="align-middle">{{player.kills}}</td>
                                 <td class="align-middle">{{player.assists}}</td>
@@ -305,18 +313,22 @@
                             ~ '.png' %}
                             <tr class="bg-{% if player.team.id == __SELF__.game.teamOne.id %}primary{% else %}danger{% endif %} text-white text-center">
                                 <th scope="row" class="text-center">
-                                    <img src="{{ path | theme}}" class="" alt="{{player.hero.title}}" title="{{player.hero.title}}" style="max-height:50px">
+                                    <img src="{{ path | theme}}" class="Icon50x" alt="{{player.hero.title}}" title="{{player.hero.title}}" loading="lazy">
                                     <p class="d-none">{{player.hero.title}}</p>
                                 </th>
                                 <td class="align-middle">
                                     {% if player.sloth %}
                                     <a href="{{'user/view' |page({id:player.sloth.id})}}" alt="Player Profile" class="text-white">
-                                                                {{player.title}}
-                                                            </a> {% else %}
-                                    <span class="text-dark">{{player.title}}</span> {% endif %}
+                                        {{player.title}}
+                                    </a>
+                                    {% else %}
+                                    <span class="text-dark">{{player.title}}</span>
+                                    {% endif %}
                                 </td>
                                 {% for talent in player.orderedTalents %} {% set path = 'assets/img/talents/' ~talent.image_url %}
-                                <td class="align-middle"><img src="{{path | theme}}" alt="{{talent.title}}" title="{{talent.title}}"></td>
+                                <td class="align-middle">
+                                    <img src="{{path | theme}}" class="Icon32x" alt="{{talent.title}}" title="{{talent.title}}" loading="lazy">
+                                </td>
                                 {% if loop.last and loop.length != 7 %} {% for i in 1..(7-loop.length) %}
                                 <td></td>
                                 {% endfor %} {% endif %} {% endfor %}

--- a/plugins/rikki/loungestatistics/components/slothstatistics/stats.htm
+++ b/plugins/rikki/loungestatistics/components/slothstatistics/stats.htm
@@ -56,7 +56,7 @@
                     <th scope="row" class="text-center">
                         <img src="{{ ('assets/img/heroes/' ~  heroArray['hero'].image_url
                                         ~ '.png') | theme }}" class="" alt="{{heroArray['hero'].title}}" title="{{heroArray['hero'].title}}"
-                            style="max-height:50px">
+                            style="max-height:50px" loading="lazy">
                         <p class="d-none">{{heroArray['hero'].title}}</p>
                     </th>
                     <td class="align-middle text-center">{{heroArray['picks']}}{% if heroArray['picks'] != '-' %}<br>({{heroArray['pick_popularity']}}%){%endif%}</td>

--- a/plugins/rikki/loungestatistics/components/teamstatistics/stats.htm
+++ b/plugins/rikki/loungestatistics/components/teamstatistics/stats.htm
@@ -33,7 +33,7 @@
                     <th scope="row" class="text-center">
                         <img src="{{ ('assets/img/heroes/' ~  heroArray['hero'].image_url
                                         ~ '.png') | theme }}" class="" alt="{{heroArray['hero'].title}}" title="{{heroArray['hero'].title}}"
-                            style="max-height:50px">
+                            style="max-height:50px" loading="lazy">
                         <p class="d-none">{{heroArray['hero'].title}}</p>
                     </th>
                     <td class="align-middle text-center">{{heroArray['picks']}}{% if heroArray['picks'] != '-' %} ({{heroArray['pick_popularity']}}%){%endif%}</td>

--- a/plugins/rikki/loungeviews/components/viewmatch/default.htm
+++ b/plugins/rikki/loungeviews/components/viewmatch/default.htm
@@ -124,11 +124,7 @@
         <div class="tab-content">
             {% for game in __SELF__.match.games %}
             <div class="tab-pane {% if loop.first %}active{% endif %}" id="game{{game.id}}" role="tabpanel">
-                {% if loop.first %}
-                    {% component 'gameStatistic' game_id = game.id lazy = 'false' %}
-                {% else %}
-                    {% component 'gameStatistic' game_id = game.id lazy= 'true' %}
-                {% endif %}                
+                {% component 'gameStatistic' game_id = game.id lazy = "{{ not loop.first }}" %}               
             </div>
             {% endfor %}
         </div>

--- a/plugins/rikki/loungeviews/components/viewmatch/default.htm
+++ b/plugins/rikki/loungeviews/components/viewmatch/default.htm
@@ -124,7 +124,7 @@
         <div class="tab-content">
             {% for game in __SELF__.match.games %}
             <div class="tab-pane {% if loop.first %}active{% endif %}" id="game{{game.id}}" role="tabpanel">
-                {% component 'gameStatistic' game_id = game.id lazy = "{{ not loop.first }}" %}               
+                {% component 'gameStatistic' game_id = game.id lazy = not loop.first %}
             </div>
             {% endfor %}
         </div>

--- a/plugins/rikki/loungeviews/components/viewmatch/default.htm
+++ b/plugins/rikki/loungeviews/components/viewmatch/default.htm
@@ -124,7 +124,11 @@
         <div class="tab-content">
             {% for game in __SELF__.match.games %}
             <div class="tab-pane {% if loop.first %}active{% endif %}" id="game{{game.id}}" role="tabpanel">
-                {% component 'gameStatistic' game_id = game.id %}
+                {% if loop.first %}
+                    {% component 'gameStatistic' game_id = game.id lazy = 'false' %}
+                {% else %}
+                    {% component 'gameStatistic' game_id = game.id lazy= 'true' %}
+                {% endif %}                
             </div>
             {% endfor %}
         </div>

--- a/themes/HeroesLounge-Theme/assets/css/custom.css
+++ b/themes/HeroesLounge-Theme/assets/css/custom.css
@@ -149,6 +149,24 @@ li#menu-item-668 {
     height:28px;
 }
 
+.Icon32x
+{
+    width: 32px;
+    height: 32px;
+}
+
+.Icon50x
+{
+    width: 50px;
+    height: 50px;
+}
+
+.Icon75x
+{
+    width: 75px;
+    height: 75px;
+}
+
 i.facebook-white,i.twitch-white,i.twitter-white,i.youtube-white,i.website-white
 {
     color:#fff;


### PR DESCRIPTION
Adds lazy loading for images as it's part of the HTML5 spec. For major browsers, only safari is missing an implementation, for a full list: [supported browsers](https://caniuse.com/#search=loading).

Default for browsers with support is `<img loading="auto">`, where the browser determines what can be lazyloaded or not. This didn't work very well for us, e.g: match/view images would get loaded in for both games even though the talent images are hidden behind a button and the 2nd or 3rd game on a different tab entirely.

This will decrease bandwidth usage for visitors that have JavaScript enabled and are using a supported browser, as it'll only fetch images from the server once they come into view.

Adds lazy loading for:
- match/view images
- sloth herostats hero images
- team herostats hero images
- round matches team logos
- upcoming matches team logos