### PR TITLE
Discordtag sync fix

### DIFF
--- a/plugins/rikki/heroeslounge/classes/discord/Attendance.php
+++ b/plugins/rikki/heroeslounge/classes/discord/Attendance.php
@@ -120,12 +120,11 @@ class Attendance
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
       curl_setopt($ch, CURLOPT_FAILONERROR, true);
       $output = curl_exec($ch);
-
       if (curl_errno($ch)) {
           return false;
       }
-
       curl_close($ch);
+
       $memberData = json_decode($output, true);
       return (isset($memberData)) ? true : false;
     }
@@ -176,12 +175,11 @@ class Attendance
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
       curl_setopt($ch, CURLOPT_FAILONERROR, true);
       $output = curl_exec($ch);
-
       if (curl_errno($ch)) {
         return "";
       }
-
       curl_close($ch);
+
       $userData = json_decode($output, true);
       return $userData["username"] . '#' . $userData["discriminator"];
     }

--- a/plugins/rikki/heroeslounge/classes/discord/Attendance.php
+++ b/plugins/rikki/heroeslounge/classes/discord/Attendance.php
@@ -165,7 +165,7 @@ class Attendance
 
     public static function getDiscordTag($discordId)
     {
-      $url = 'https://discordapp.com/api/guilds/200267155479068672/members/' . $discordId;
+      $url = 'https://discordapp.com/api/users/' . $discordId;
 
       $auth_header = AuthCode::getCode();
       $headers = [
@@ -181,16 +181,11 @@ class Attendance
       $output = curl_exec($ch);
 
       if (curl_errno($ch)) {
-          return "";
-      }
-
-      $memberData = json_decode($output, true);
-      curl_close($ch);
-
-      if (isset($memberData)) {
-        return $memberData["user"]["username"] . '#' . $memberData["user"]["discriminator"];
-      } else {
         return "";
       }
+
+      curl_close($ch);
+      $userData = json_decode($output, true);
+      return $userData["username"] . '#' . $userData["discriminator"];
     }
 }

--- a/plugins/rikki/heroeslounge/classes/discord/Attendance.php
+++ b/plugins/rikki/heroeslounge/classes/discord/Attendance.php
@@ -118,19 +118,16 @@ class Attendance
       $ch = curl_init($url);
       curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
+      curl_setopt($ch, CURLOPT_FAILONERROR, true);
       $output = curl_exec($ch);
 
       if (curl_errno($ch)) {
           return false;
       }
 
-      $memberData = json_decode($output, true);
-
       curl_close($ch);
-
+      $memberData = json_decode($output, true);
       return (isset($memberData)) ? true : false;
-
     }
 
     public static function CreateDiscordTagArray($users)
@@ -177,7 +174,7 @@ class Attendance
       $ch = curl_init($url);
       curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-
+      curl_setopt($ch, CURLOPT_FAILONERROR, true);
       $output = curl_exec($ch);
 
       if (curl_errno($ch)) {


### PR DESCRIPTION
No longer relies on a user being present in the Heroes Lounge Discord to be able to sync their Discord tag. Also added `CURLOPT_FAILONERROR` to error requests with status codes >=400.