### PR TITLE
Fix mailchimp during registration

### DIFF
--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -18,6 +18,7 @@ use RainLab\User\Models\Settings as UserSettings;
 use Exception;
 
 use RainLab\User\Components\Account as UserAccount;
+use RainLab\User\Models\User;
 use Rikki\Heroeslounge\classes\Discord;
 use Rikki\Heroeslounge\Models\Sloth as SlothModel;
 use Rikki\Heroeslounge\Models\Season as Seasons;
@@ -230,13 +231,12 @@ class SlothAccount extends UserAccount
             $sloth->region_id = $data['region_id'];
             $sloth->save();
 
-            $this->user = $sloth->user;
-
+            $user = User::where('username', $sloth->title)->first();
             // sign up for newsletter
             if (array_key_exists('newsletter_subscription', $data) && $data['newsletter_subscription']) {
-                MailChimpAPI::subscribeNewUser($sloth->user);
+                MailChimpAPI::subscribeNewUser($user);
             } else {
-                MailChimpAPI::unsubscribeNewUser($sloth->user);
+                MailChimpAPI::unsubscribeNewUser($user);
             }
 
             /*

--- a/plugins/rikki/heroeslounge/components/SlothAccount.php
+++ b/plugins/rikki/heroeslounge/components/SlothAccount.php
@@ -231,7 +231,7 @@ class SlothAccount extends UserAccount
             $sloth->region_id = $data['region_id'];
             $sloth->save();
 
-            $user = User::where('username', $sloth->title)->first();
+            $user = User::where('username', $sloth->title)->firstOrFail();
             // sign up for newsletter
             if (array_key_exists('newsletter_subscription', $data) && $data['newsletter_subscription']) {
                 MailChimpAPI::subscribeNewUser($user);


### PR DESCRIPTION
Now passes in an up to date user to the Mailchimp api instead of the incomplete reference we had leftover from registration.

During registration we create and save a new sloth and attach the user we get from our auth provider. However after saving our sloth the `$sloth->user` user reference is unaware of what sloth it's been attached to. 

Fetching from the database get us an up to date usermodel instance, which is updated.