### PR TITLE
Add scheduled job for HeroUpdater

### DIFF
--- a/plugins/rikki/heroeslounge/Plugin.php
+++ b/plugins/rikki/heroeslounge/Plugin.php
@@ -99,9 +99,8 @@ class Plugin extends PluginBase
         })->dailyAt('1:30');
         
         $schedule->call(function () {
-            //$hu = new HeroUpdater;
-            //$hu->updateHeroes();
-        })->weekly()->thursdays()->at('4:00');
+            HeroUpdater::updateHeroes();
+        })->weekly()->tuesdays()->at('4:00');
     }
 
     public function boot()


### PR DESCRIPTION
I went for Tuesdays, since game patches tend to happen on Wednesday, so it'd likely give our image source the most time to update their information, since I don't think it's automated on their end.

I saw that we have a scheduled task for fetching heroprotocol, do we still need this considering we try to update the protocol when parsing fails?