### PR TITLE
Talent image fetch fix

### DIFF
--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -116,7 +116,6 @@ class HeroUpdater
             mkdir($talent_image_path, 0777, true);
         }
 
-        // Check if the file already exists and if it's larger than 500 bytes.
         if (file_exists($talent_image_path.DS.$icon_url) && filesize($talent_image_path.DS.$icon_url) >= 500) {
             return;
         }

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -116,8 +116,8 @@ class HeroUpdater
             mkdir($talent_image_path, 0777, true);
         }
 
-        // Check if we already have the talent image.
-        if (file_exists($talent_image_path.DS.$icon_url)) {
+        // Check if the file already exists and if it's larger than 500 bytes.
+        if (file_exists($talent_image_path.DS.$icon_url) && filesize($talent_image_path.DS.$icon_url) >= 500) {
             return;
         }
 

--- a/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
+++ b/plugins/rikki/heroeslounge/classes/heroes/HeroUpdater.php
@@ -62,11 +62,11 @@ class HeroUpdater
                     $talent->replay_title = $talent_data['talentTreeId'];
                     $talent->save();
                     Log::info('New talent added: '.$talent_data['name']);
+                } else {
+                    $talent = Talent::where('title', $talent_data['name'])->where('hero_id', $hero_model->id)->first();
                 }
 
-                if ($talent) {
-                    Self::setTalentImage($talent, $talent_data['icon']);
-                }
+                Self::setTalentImage($talent, $talent_data['icon']);
             }
         }
     }

--- a/themes/HeroesLounge-Theme/assets/img/talents/LICENSE
+++ b/themes/HeroesLounge-Theme/assets/img/talents/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Heroes Patch Notes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/themes/HeroesLounge-Theme/assets/img/talents/README.md
+++ b/themes/HeroesLounge-Theme/assets/img/talents/README.md
@@ -1,0 +1,3 @@
+Heroes Lounge sources their talent images from the [Heroes Patchnotes heroes-talents](https://github.com/heroespatchnotes/heroes-talents) respository.
+
+The license to use these images can be found [here](./LICENSE).


### PR DESCRIPTION
There were two problems with my previous implementation.

1. The logic for updating partial talents that we created during replay parsing should have come first, since instead of updating this partial talent we were creating a new one. This change will try to update partial talents before creating new talents. This means that for some talents we're going to have duplicate entries, but that should not be a problem. (These entries need to stay, because they may have associations in `rikki_heroeslounge_gameparticipation_talent`).

2. The logic assumed that talents for which we have all the information have an image stored on disk, however in practice this does not always seem to be the case. The new logic will always call `setTalentImage`, but checks if we already have an entry on disk.