### PR TITLE
Casterscheduling page fix

### DIFF
--- a/plugins/rikki/heroeslounge/components/CasterSchedule.php
+++ b/plugins/rikki/heroeslounge/components/CasterSchedule.php
@@ -3,7 +3,7 @@
  
 
 use Cms\Classes\ComponentBase;
-use Rikki\Heroeslounge\Models\Sloth as Sloths;
+use Rikki\Heroeslounge\Models\Sloth;
 use Auth;
 
 class CasterSchedule extends ComponentBase
@@ -19,50 +19,53 @@ class CasterSchedule extends ComponentBase
     public $caster = null;
     public function init()
     {
-        $this->caster = Auth::getUser()->sloth;
+        $user = Auth::getUser();
+        if ($user) {
+            $this->caster = Sloth::getFromUser($user);
 
-        $component = $this->addComponent(
-                        'Rikki\Heroeslounge\Components\UpcomingMatches',
-                        'upcomingMatchesPending',
-                        [
-                            'deferredBinding'   => true,
-                            'daysInFuture'           => $this->property('daysInFuture'),
-                            'showLogo'          => true,
-                            'showName' => false,
-                            'type' => 'caster',
-                            'showCasters' => true,
-                            'id' => $this->caster->id,
-                            'casterFilter' => 'pending'
-                        ]
-                    );
-        $component = $this->addComponent(
-                        'Rikki\Heroeslounge\Components\UpcomingMatches',
-                        'upcomingMatchesAccepted',
-                        [
-                            'deferredBinding'   => true,
-                            'daysInFuture'           => $this->property('daysInFuture'),
-                            'showLogo'          => true,
-                            'showName' => false,
-                            'type' => 'caster',
-                            'showCasters' => true,
-                            'id' => $this->caster->id,
-                            'casterFilter' => 'accepted'
-                        ]
-                    );
-        $component = $this->addComponent(
-                        'Rikki\Heroeslounge\Components\UpcomingMatches',
-                        'upcomingMatchesDenied',
-                        [
-                            'deferredBinding'   => true,
-                            'daysInFuture'           => $this->property('daysInFuture'),
-                            'showLogo'          => true,
-                            'showName' => false,
-                            'type' => 'caster',
-                            'showCasters' => true,
-                            'id' => $this->caster->id,
-                            'casterFilter' => 'denied'
-                        ]
-                    );
+            $component = $this->addComponent(
+                            'Rikki\Heroeslounge\Components\UpcomingMatches',
+                            'upcomingMatchesPending',
+                            [
+                                'deferredBinding'   => true,
+                                'daysInFuture'           => $this->property('daysInFuture'),
+                                'showLogo'          => true,
+                                'showName' => false,
+                                'type' => 'caster',
+                                'showCasters' => true,
+                                'id' => $this->caster->id,
+                                'casterFilter' => 'pending'
+                            ]
+                        );
+            $component = $this->addComponent(
+                            'Rikki\Heroeslounge\Components\UpcomingMatches',
+                            'upcomingMatchesAccepted',
+                            [
+                                'deferredBinding'   => true,
+                                'daysInFuture'           => $this->property('daysInFuture'),
+                                'showLogo'          => true,
+                                'showName' => false,
+                                'type' => 'caster',
+                                'showCasters' => true,
+                                'id' => $this->caster->id,
+                                'casterFilter' => 'accepted'
+                            ]
+                        );
+            $component = $this->addComponent(
+                            'Rikki\Heroeslounge\Components\UpcomingMatches',
+                            'upcomingMatchesDenied',
+                            [
+                                'deferredBinding'   => true,
+                                'daysInFuture'           => $this->property('daysInFuture'),
+                                'showLogo'          => true,
+                                'showName' => false,
+                                'type' => 'caster',
+                                'showCasters' => true,
+                                'id' => $this->caster->id,
+                                'casterFilter' => 'denied'
+                            ]
+                        );
+        }
     }
 
     public function defineProperties()

--- a/plugins/rikki/heroeslounge/components/casterschedule/default.htm
+++ b/plugins/rikki/heroeslounge/components/casterschedule/default.htm
@@ -11,4 +11,8 @@
 <h3>Denied Applications</h3>
 {% component 'upcomingMatchesDenied' %}
 </div>
+{% else %}
+<div>
+  You must be a caster to sign up to cast matches.
+</div>
 {% endif %}

--- a/themes/HeroesLounge-Theme/pages/user/casterschedule.htm
+++ b/themes/HeroesLounge-Theme/pages/user/casterschedule.htm
@@ -6,4 +6,11 @@ is_hidden = 0
 [CasterSchedule]
 daysInFuture = 50
 ==
+
+{% if user %}
 {% component 'CasterSchedule' %}
+{% else %}
+<div>
+  You must be logged in to view this page.
+</div>
+{% endif %}


### PR DESCRIPTION
Adds a check if you're logged in when navigating to the caster scheduling page.

Also adds "warning" explanations when navigating to the page if you're not logged in or eligible to cast matches.