### PR TITLE
Match page performance

### DIFF
--- a/plugins/rikki/loungestatistics/components/GameStatistics.php
+++ b/plugins/rikki/loungestatistics/components/GameStatistics.php
@@ -28,6 +28,9 @@ class GameStatistics extends ComponentBase
     public function onRender()
     {
         $this->game = Game::find($this->property('game_id'));
+        if ($this->game->winner_id) {
+            $this->game->load('gameParticipations', 'gameParticipations.sloth', 'gameParticipations.hero', 'gameParticipations.talents');
+        }
         $this->lazy = $this->property('lazy') ? 'lazy' : 'auto';
     }
 

--- a/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
+++ b/plugins/rikki/loungestatistics/components/gamestatistics/default.htm
@@ -325,7 +325,7 @@
                                     <span class="text-dark">{{player.title}}</span>
                                     {% endif %}
                                 </td>
-                                {% for talent in player.orderedTalents %} {% set path = 'assets/img/talents/' ~talent.image_url %}
+                                {% for talent in player.talents|sort((a, b) => a.talent_tier > b.talent_tier) %} {% set path = 'assets/img/talents/' ~talent.image_url %}
                                 <td class="align-middle">
                                     <img src="{{path | theme}}" class="Icon32x" alt="{{talent.title}}" title="{{talent.title}}" loading="lazy">
                                 </td>


### PR DESCRIPTION
This change introduces lazy eager loading for games when they have a winner to reduce the number of database queries.

The `orderedTalents ` attribute always called the database to get the talents and order them by talent_tier. This requires 10 database calls per match game, slowing down the query. Sorting in php allows us to leverage the eagerly loaded talent data.

