### PR TITLE
Backend performance

### DIFF
--- a/plugins/rikki/heroeslounge/controllers/casterscheduling/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/casterscheduling/config_relation.yaml
@@ -34,10 +34,15 @@ casters:
         showSearch: false
         showCheckboxes: true
     manage:
+        showSearch: true
+        recordsPerPage: 20
         list:
             columns:
                 title:
                     label: Name
+                    type: text
+                    searchable: true
+                    sortable: true
                 pivot[approved]:
                     label: Status
         scope: IsCaster

--- a/plugins/rikki/heroeslounge/controllers/division/config_list.yaml
+++ b/plugins/rikki/heroeslounge/controllers/division/config_list.yaml
@@ -3,8 +3,13 @@ modelClass: Rikki\Heroeslounge\Models\Division
 list: $/rikki/heroeslounge/models/division/columns.yaml
 recordUrl: 'rikki/heroeslounge/division/update/:id'
 noRecordsMessage: 'backend::lang.list.no_records'
+recordsPerPage: '20'
 showSetup: true
 showCheckboxes: true
+showSorting: 1
+defaultSort:
+    column: title
+    direction: asc
 toolbar:
     buttons: list_toolbar
     search:

--- a/plugins/rikki/heroeslounge/controllers/division/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/division/config_relation.yaml
@@ -10,6 +10,8 @@ teams:
         toolbarButtons: add|remove
     manage:
         showSearch: true
+        recordsPerPage: 20
+        list: $/rikki/heroeslounge/models/team/relation_columns.yaml
 timeline:
     label: Timeline Entries
     view:

--- a/plugins/rikki/heroeslounge/controllers/playoff/config_list.yaml
+++ b/plugins/rikki/heroeslounge/controllers/playoff/config_list.yaml
@@ -3,8 +3,10 @@ modelClass: Rikki\Heroeslounge\Models\Playoff
 list: $/rikki/heroeslounge/models/playoff/columns.yaml
 recordUrl: 'rikki/heroeslounge/playoff/update/:id'
 noRecordsMessage: 'backend::lang.list.no_records'
+recordsPerPage: '20'
 showSetup: true
 showCheckboxes: true
+showSorting: 1
 toolbar:
     buttons: list_toolbar
     search:


### PR DESCRIPTION
Adds pagination and searching to some more backend pages. This should also help decrease performance use a fair bit when moderators assign teams to divisions.