### PR TITLE
Basic Single Playoff permissions

### DIFF
--- a/plugins/rikki/heroeslounge/controllers/Match.php
+++ b/plugins/rikki/heroeslounge/controllers/Match.php
@@ -13,7 +13,7 @@ class Match extends Controller
 {
     public $implement = ['Backend\Behaviors\ListController','Backend\Behaviors\FormController',
     'Backend\Behaviors\RelationController'];
-    public $requiredPermissions = ['rikki.heroeslounge.match'];
+    public $requiredPermissions = ['rikki.heroeslounge.match', 'rikki.heroeslounge.single_playoff'];
     public $formConfig = 'config_form.yaml';
     public $relationConfig = 'config_relation.yaml';
     public $listConfig = 'config_list.yaml';

--- a/plugins/rikki/heroeslounge/controllers/Playoff.php
+++ b/plugins/rikki/heroeslounge/controllers/Playoff.php
@@ -11,7 +11,7 @@ use Redirect;
 class Playoff extends Controller
 {
     public $implement = ['Backend\Behaviors\ListController','Backend\Behaviors\FormController', 'Backend\Behaviors\RelationController'];
-    public $requiredPermissions = ['rikki.heroeslounge.season'];
+    public $requiredPermissions = ['rikki.heroeslounge.season', 'rikki.heroeslounge.single_playoff'];
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
     public $relationConfig = 'config_relation.yaml';

--- a/plugins/rikki/heroeslounge/controllers/PlayoffRedirect.php
+++ b/plugins/rikki/heroeslounge/controllers/PlayoffRedirect.php
@@ -1,0 +1,24 @@
+<?php namespace Rikki\Heroeslounge\Controllers;
+
+use BackendMenu;
+use Backend\Classes\Controller;
+
+/**
+ * Playoff Redirect Back-end Controller
+ */
+class PlayoffRedirect extends Controller
+{
+    public $requiredPermissions = ['rikki.heroeslounge.season', 'rikki.heroeslounge.single_playoff'];
+    public function __construct()
+    {
+        parent::__construct();        
+        BackendMenu::setContext('Rikki.Heroeslounge', 'heroeslounge', 'playoffredirect');
+    }
+
+    public function index(){
+        if (!$this->user->hasAccess(['rikki.heroeslounge.season'])) {
+            return redirect('/backend/rikki/heroeslounge/playoff');
+        }
+        return redirect('/backend/rikki/heroeslounge/season');
+    }
+}

--- a/plugins/rikki/heroeslounge/controllers/match/_list_toolbar.htm
+++ b/plugins/rikki/heroeslounge/controllers/match/_list_toolbar.htm
@@ -1,5 +1,5 @@
- 
 <div data-control="toolbar">
+    <?php if ($this->user->hasAccess('rikki.heroeslounge.match')){ ?>
         <a href="<?= Backend::url('rikki/heroeslounge/match/create') ?>" class="btn btn-primary oc-icon-plus"><?= e(trans('backend::lang.form.create')) ?></a>
         <button
         class="btn btn-default oc-icon-trash-o"
@@ -16,4 +16,5 @@
         data-stripe-load-indicator>
         <?= e(trans('backend::lang.list.delete_selected')) ?>
     </button>
+    <?php } ?>
 </div>

--- a/plugins/rikki/heroeslounge/controllers/playoff/_admins.htm
+++ b/plugins/rikki/heroeslounge/controllers/playoff/_admins.htm
@@ -1,0 +1,1 @@
+<?= $this->relationRender('backend_users') ?>

--- a/plugins/rikki/heroeslounge/controllers/playoff/_divisions.htm
+++ b/plugins/rikki/heroeslounge/controllers/playoff/_divisions.htm
@@ -1,1 +1,3 @@
-<?= $this->relationRender('divisions') ?>
+<?= ($this->user->hasAccess('rikki.heroeslounge.single_playoff') ||
+!$this->user->hasAccess('rikki.heroeslounge.season')) ?
+$this->relationRender('divisions',['readOnly' => true]) : $this->relationRender('divisions') ?>

--- a/plugins/rikki/heroeslounge/controllers/playoff/_list_toolbar.htm
+++ b/plugins/rikki/heroeslounge/controllers/playoff/_list_toolbar.htm
@@ -1,5 +1,6 @@
  
 <div data-control="toolbar">
+    <?php if ($this->user->hasAccess('rikki.heroeslounge.season')){ ?>
         <a href="<?= Backend::url('rikki/heroeslounge/playoff/create') ?>" class="btn btn-primary oc-icon-plus"><?= e(trans('backend::lang.form.create')) ?></a>
         <button
         class="btn btn-default oc-icon-trash-o"
@@ -16,4 +17,5 @@
         data-stripe-load-indicator>
         <?= e(trans('backend::lang.list.delete_selected')) ?>
     </button>
+    <?php } ?>
 </div>

--- a/plugins/rikki/heroeslounge/controllers/playoff/config_relation.yaml
+++ b/plugins/rikki/heroeslounge/controllers/playoff/config_relation.yaml
@@ -40,4 +40,31 @@ divisions:
         toolbarButtons: create|add|remove
     manage:
         form: $/rikki/heroeslounge/models/division/create_fields.yaml
-        
+backend_users:
+    label: Admin
+    view:
+        list:
+            columns:
+                login:
+                    label: Username
+                email:
+                    label: Email
+                first_name:
+                    label: First Name
+                last_name:
+                    label: Last Name
+        toolbarButtons: link|unlink
+    manage:
+        list:
+            columns:
+                login:
+                    label: Username
+                email:
+                    label: Email
+                first_name:
+                    label: First Name
+                last_name:
+                    label: Last Name
+        showSearch: true
+        recordsPerPage: 20
+    emptyMessage: There are no backend users to be assigned.

--- a/plugins/rikki/heroeslounge/models/Playoff.php
+++ b/plugins/rikki/heroeslounge/models/Playoff.php
@@ -6,6 +6,7 @@ use Rikki\Heroeslounge\Models\Match;
 use Rikki\Heroeslounge\Classes\Helpers\TimezoneHelper;
 use Carbon\Carbon;
 use Log;
+use BackendAuth;
 
 class Playoff extends Model
 {
@@ -36,7 +37,35 @@ class Playoff extends Model
             'table' => 'rikki_heroeslounge_team_playoff',
             'pivot' => ['seed']
         ],
+        'backend_users' =>
+        [
+            'Backend\Models\User',
+            'key' => 'playoff_id',
+            'otherKey' => 'backend_user_id',
+            'table' => 'rikki_heroeslounge_backend_users_playoff'
+        ]
     ];
+
+    protected static function boot()
+    {
+        parent::boot();
+        // Check if BackendAuth exists, as its missing in some environments like console commands / cronjobs
+        if (class_exists('BackendAuth')) {
+            $user = BackendAuth::getUser();
+            // Check if the user really exists
+            if (is_object($user)) {
+                // Add scope that only shows playoffs that the user has access to
+                static::addGlobalScope('limit_playoff_access', function ($builder) use ($user) {
+                    $builder->whereHas(
+                        'backend_users',
+                        function ($backendUserBuilder) use ($user) {
+                            $backendUserBuilder->where('backend_users.id', $user->id);
+                        }
+                    );
+                });
+            }
+        }
+    }
 
     public function getLongTitleAttribute() 
     {

--- a/plugins/rikki/heroeslounge/models/playoff/fields.yaml
+++ b/plugins/rikki/heroeslounge/models/playoff/fields.yaml
@@ -48,3 +48,9 @@ tabs:
             type: partial
             path: ~/plugins/rikki/heroeslounge/controllers/playoff/_teams.htm
             tab: Groups & Teams
+        admins:
+            label: Admins for this playoff
+            type: partial
+            path: ~/plugins/rikki/heroeslounge/controllers/playoff/_admins.htm
+            tab: General
+            permissions: rikki.heroeslounge.season

--- a/plugins/rikki/heroeslounge/plugin.yaml
+++ b/plugins/rikki/heroeslounge/plugin.yaml
@@ -7,10 +7,11 @@ plugin:
 navigation:
     manage-seasons:
         label: 'Manage Seasons'
-        url: rikki/heroeslounge/season
+        url: rikki/heroeslounge/playoffredirect
         icon: icon-tag
         permissions:
             - rikki.heroeslounge.league
+            - rikki.heroeslounge.single_playoff
         order: '4'
         sideMenu:
             manage-seasons:
@@ -25,6 +26,7 @@ navigation:
                 icon: icon-tag
                 permissions:
                     - rikki.heroeslounge.season
+                    - rikki.heroeslounge.single_playoff
             manage-divisions:
                 label: 'Manage Divisions'
                 url: rikki/heroeslounge/division
@@ -101,6 +103,7 @@ navigation:
         icon: icon-futbol-o
         permissions:
             - rikki.heroeslounge.matches
+            - rikki.heroeslounge.single_playoff
         order: '3'
         sideMenu:
             manage-matches:
@@ -109,6 +112,7 @@ navigation:
                 icon: icon-futbol-o
                 permissions:
                     - rikki.heroeslounge.match
+                    - rikki.heroeslounge.single_playoff
 permissions:
     rikki.heroeslounge.match:
         tab: 'rikki.heroeslounge::lang.plugin.name'
@@ -122,6 +126,9 @@ permissions:
     rikki.heroeslounge.casterscheduling:
         tab: 'rikki.heroeslounge::lang.plugin.name'
         label: 'Appove casters, assign channels'
+    rikki.heroeslounge.single_playoff:
+        tab: 'rikki.heroeslounge::lang.plugin.name'
+        label: 'Manage Single playoffs and its matches'
     rikki.heroeslounge.division:
         tab: 'rikki.heroeslounge::lang.plugin.name'
         label: 'Manage Divisions'

--- a/plugins/rikki/heroeslounge/updates/builder_table_create_rikki_heroeslounge_backend_users_playoff.php
+++ b/plugins/rikki/heroeslounge/updates/builder_table_create_rikki_heroeslounge_backend_users_playoff.php
@@ -1,0 +1,25 @@
+<?php namespace Rikki\Heroeslounge\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableCreateRikkiHeroesloungeBackendUserPlayoff extends Migration
+{
+    public function up()
+    {
+        Schema::create('rikki_heroeslounge_backend_users_playoff', function($table)
+        {
+            $table->engine = 'InnoDB';
+            $table->increments('id')->unsigned();
+            $table->integer('backend_user_id')->unsigned();
+            $table->integer('playoff_id')->unsigned();
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+    
+    public function down()
+    {
+        Schema::dropIfExists('rikki_heroeslounge_backend_users_playoff');
+    }
+}

--- a/plugins/rikki/heroeslounge/updates/version.yaml
+++ b/plugins/rikki/heroeslounge/updates/version.yaml
@@ -413,3 +413,6 @@
 1.0.144:
     - 'Updated table rikki_heroeslounge_api_keys'
     - builder_table_update_rikki_heroeslounge_api_keys2.php
+1.0.145:
+    - 'Create table rikki_heroeslounge_backend_users_playof'
+    - builder_table_create_rikki_heroeslounge_backend_users_playoff.php


### PR DESCRIPTION
This is a rather basic implementation of a limited playoff / matches admin. They can edit playoffs they were assigned to as admin, but not the divisions (groups). The ability to create new playoffs is hidden in the UI, but theoretically they can circumvent that right now and create one (and lose access to it immediately). Same for matches, they can edit matches of the playoff they are assigned to. The playoff and match list are limited to their assigned playoffs. I would argue this will probably be sufficient, since most people we trust enough to get access at all won't try too hard to circumvent it, and if they do they get banned. Its not like they can actually really fuck anything up, but YMMV.