### PR TITLE
Remove deprecated xampp version, modified the file to work with the current latest version and updated documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,22 @@ On OS X, install with Brew: https://brew.sh/
 
 On Linux you should be able to figure this out yourself. ;)
 
+Once Vagrant is installed, head to your desired folder and clone the repository:
+
+```bash
+git clone https://github.com/Fabian-Sommer/HeroesLounge.git
+cd HeroesLounge
+```
+
+Next, we download xampp version `xampp-linux-x64-8.2.12-0-installer.run` and place it inside the HeroesLounge directory.
+
+**NOTE: If you downloaded a more up-to-date xampp version, you must modify `install_october.sh` file, more specifically line 10 - `cp /vagrant/xampp-linux-x64-8.2.12-0-installer.run .` and replace `xampp-linux-x64-8.2.12-0-installer.run` with your xampp file version name.**
+
 Now run the Virtualbox UI and make sure that the Virtualbox Guest Additions are up to date with the Virtualbox version (it should prompt you automatically if not).
 
 
 Download the database zip from the link you should have received (discord pins/email from team) and put it in this directory (after cloning this repo locally).
+
 
 Run Vagrant:
 

--- a/install_october.sh
+++ b/install_october.sh
@@ -3,7 +3,11 @@
 BASE=/opt/lampp
 HTDOCS=$BASE/htdocs
 
-wget https://www.apachefriends.org/xampp-files/7.2.14/xampp-linux-x64-7.2.14-0-installer.run
+# Remove existing installer if any
+rm -f xampp-linux-*-installer.run
+
+# Copy from shared folder instead of downloading
+cp /vagrant/xampp-linux-x64-8.2.12-0-installer.run .
 chmod +x xampp-linux-*-installer.run
 sudo ./xampp-linux-*-installer.run
 rm ./xampp-linux-*-installer.run


### PR DESCRIPTION
Current xampp version threw a lot of errors as the link no longer exists.

Replacing it with the official mirror link may not always connect you to the proper server, causing you to download the file with 10 KB/s taking up to 5 hours of download.

Best choice is manual xampp installation with modified `install_october.sh` file which doesn't throw any errors and happens instantly.

Documentation has been updated with proper instructions following the above updates.