### PR TITLE
Accept non-canonical timezone identifiers during detection

### DIFF
--- a/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
+++ b/plugins/rikki/heroeslounge/classes/helpers/TimezoneHelper.php
@@ -7,6 +7,7 @@ use Redirect;
 use Log;
 use DateTime;
 use DateTimeZone;
+use Exception;
 
 class TimezoneHelper
 {
@@ -51,16 +52,30 @@ class TimezoneHelper
 
     public static function setTimezone()
     {
-        if (isset($_POST[self::TIMEZONE_KEY])) {
-            $timezoneName = $_POST[self::TIMEZONE_KEY];
-        } else {
-            $timezoneName = self::defaultTimezone();
+        $timezoneName = isset($_POST[self::TIMEZONE_KEY]) ? $_POST[self::TIMEZONE_KEY] : null;
+
+        if (!is_string($timezoneName) || !self::isValidTimezone($timezoneName)) {
+            // Leave the session alone so hasTimezone() stays false and detection
+            // is retried on the next page load, instead of pinning the visitor
+            // to the default timezone for the rest of the session.
+            return;
         }
-        if (!in_array($timezoneName, timezone_identifiers_list())) {
-            $timezoneName = self::defaultTimezone();
-        }
+
         Session::put(self::TIMEZONE_KEY, $timezoneName);
         return Redirect::refresh();
+    }
+
+    private static function isValidTimezone($timezoneName)
+    {
+        // timezone_identifiers_list() only returns the canonical identifiers, so it
+        // rejects the backwards compatible aliases browsers still report, such as
+        // Europe/Kiev, Asia/Calcutta and Etc/GMT+5. All of them are valid here.
+        try {
+            new DateTimeZone($timezoneName);
+            return true;
+        } catch (Exception $e) {
+            return false;
+        }
     }
 
     public static function hasTimezone()


### PR DESCRIPTION
Automatic timezone detection silently fell back to UTC for a range of valid timezones, and the fallback stuck for the whole session.

## Root cause

`TimezoneHelper::setTimezone()` validated the browser-reported zone with `timezone_identifiers_list()`, which returns only the 419 canonical identifiers and omits the 178 backwards compatible aliases that PHP itself accepts. Any of those was replaced with the default timezone.

It then wrote that fallback into the session regardless. Since `hasTimezone()` gates whether the detection script is rendered at all, one failed detection pinned the visitor to UTC for the rest of the session with no retry and no way to correct it.

## Impact

Windows reports `Europe/Kiev` for the whole "FLE Standard Time" group when the region setting doesn't match the timezone, so players in **Lithuania, Latvia, Estonia, Finland, Bulgaria and Ukraine** were affected. This was reported by a Lithuanian player who confirmed `Intl.DateTimeFormat().resolvedOptions().timeZone` returns `Europe/Kiev` on their machine.

Also fixed: `Asia/Calcutta` (India), `Asia/Saigon` (Vietnam), `Asia/Dacca` (Bangladesh), `America/Buenos_Aires` (Argentina), `Europe/Nicosia` (Cyprus), `America/Indianapolis`, and `Etc/GMT±N` / bare `EET` / `CET` for anyone whose OS uses a fixed offset.

## Changes

- Validate by constructing a `DateTimeZone` rather than checking list membership. The `is_string()` guard prevents a `TypeError` if `$_POST` holds an array.
- Return without writing the session when detection fails, so `hasTimezone()` stays false and detection is retried on the next page load.

## Verification

Exercised the real helper with the framework facades stubbed. Against the unmodified code: 3 passed, 9 failed. After: **12 passed, 0 failed** — covering `Europe/Kiev`, `Asia/Calcutta`, `Etc/GMT+5`, `US/Eastern`, plus rejection of invalid, empty, absent and array input without writing the session.

Confirmed `Europe/Kiev` and `Europe/Vilnius` have **zero** offset mismatches across 2026–2027 with DST transitions on the correct dates, so affected players get correct times and not merely an accepted value. `php -l` clean.

## Note for deploying

Existing sessions keep the stale `UTC` value until they expire, since `hasTimezone()` is already true for them. Test in a private window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vRGBhq9N4vXKGEY4edcU7
